### PR TITLE
ci: 添加 NPM 自动发布流程

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,41 @@
+name: Publish NPM package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish dsh-bottom-info-bar to NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify tag matches package version
+        working-directory: plugin
+        shell: bash
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          package_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$package_version" ]; then
+            echo "Tag version $tag_version does not match package version $package_version"
+            exit 1
+          fi
+
+      - name: Publish package
+        working-directory: plugin
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 改动
- 新增 `.github/workflows/publish-npm.yml`
- 只在 `v*.*.*` tag 推送时发布
- 校验 Git tag 与 `plugin/package.json` 版本一致
- 使用仓库中的 `NPM_TOKEN` Secret
- 支持手动触发，便于首次发布已有版本

## 验证
- `npm pack --dry-run` 成功
- 发布包仅包含构建产物和必要元数据