### PR TITLE
ci: update npm publish action runtimes

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out release tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
Updates the publish workflow to the current checkout and setup-node action major versions, eliminating the Node 20 deprecation warning seen during the v1.5.0 publish run.