### PR TITLE
fix(pricing): 周末全天空闲价（DeepSeek 2026-08-23 新规），并修正跨周末的倒计时

### DIFF
--- a/plugin/src/host.js
+++ b/plugin/src/host.js
@@ -650,22 +650,41 @@ export default {
     }
 
     // ---------- 北京时间峰谷判定 ----------
+    // 官方 2026-08-23（周日）00:00 北京时间起：周末（按北京日历的周六、周日）
+    // 全天按空闲价计费。该时刻换算成 UTC 是 2026-08-22T16:00:00Z。
+    // 生效前的时间点仍按旧规则结算，所以回放旧账本不会被改价。
+    const WEEKEND_OFFPEAK_FROM_MS = Date.UTC(2026, 7, 22, 16, 0, 0);
     function beijingMinutes(nowMs) {
       const d = new Date(nowMs + 8 * 3600 * 1000);
       return d.getUTCHours() * 60 + d.getUTCMinutes();
     }
+    // 「是不是周末」看的是北京日历，不是 UTC 日历：北京的周末从周五 16:00 UTC
+    // 一直到周日 16:00 UTC。所以星期几必须从同一个平移过的时间上取。
+    function isWeekendOffPeak(nowMs) {
+      if (nowMs < WEEKEND_OFFPEAK_FROM_MS) return false;
+      const day = new Date(nowMs + 8 * 3600 * 1000).getUTCDay();
+      return day === 0 || day === 6;
+    }
     function currentPeriod(nowMs) {
+      if (isWeekendOffPeak(nowMs)) return 'offpeak';
       const m = beijingMinutes(nowMs);
       return (m >= 9 * 60 && m < 12 * 60) || (m >= 14 * 60 && m < 18 * 60) ? 'peak' : 'offpeak';
     }
+    // 周末整天没有切换点，所以要一天一天往前找，跳过周末。原来的写法在周日
+    // 09:30 会说「2 小时 30 分后进高峰」,而下一次进高峰其实是周一早上。
     function nextSwitchAt(nowMs) {
       const d = new Date(nowMs + 8 * 3600 * 1000);
       const cur = d.getUTCHours() * 60 + d.getUTCMinutes();
       const bounds = [9, 12, 14, 18];
-      for (let i = 0; i < bounds.length; i++) {
-        const b = bounds[i] * 60;
-        if (b > cur) {
-          return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), bounds[i], 0, 0) - 8 * 3600 * 1000).getTime();
+      const weekendRuleActive = nowMs >= WEEKEND_OFFPEAK_FROM_MS;
+      for (let ahead = 0; ahead <= 7; ahead++) {
+        const day = (d.getUTCDay() + ahead) % 7;
+        if (weekendRuleActive && (day === 0 || day === 6)) continue;
+        for (let i = 0; i < bounds.length; i++) {
+          const b = ahead * 1440 + bounds[i] * 60;
+          if (b > cur) {
+            return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + ahead, bounds[i], 0, 0) - 8 * 3600 * 1000).getTime();
+          }
         }
       }
       return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1, 9, 0, 0) - 8 * 3600 * 1000).getTime();

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -33,6 +33,7 @@ const cases = [
   ['test-usage-ledger（耐久账本与历史价格）', ['tests/test-usage-ledger.mjs'], join(root), process.execPath],
   ['test-usage-stream-ledger（每次回答只记一笔）', ['tests/test-usage-stream-ledger.mjs'], join(root), process.execPath],
   ['test-host-regressions（host.js 审计必修项回归）', ['tests/test-host-regressions.mjs'], join(root), process.execPath],
+  ['test-weekend-offpeak（周末全天空闲价，走 getPricing 真实路径）', ['tests/test-weekend-offpeak.mjs'], join(root), process.execPath],
   ['test-update-check（启动版本检查与红色提醒）', ['tests/test-update-check.js'], join(root), process.execPath],
   ['check-host（host.js）', ['tests/check-host.js', HOST], join(root), process.execPath],
 ]

--- a/tests/test-spend-accounting.js
+++ b/tests/test-spend-accounting.js
@@ -43,7 +43,14 @@ function beijingDayKey(ts) {
   const d = new Date(ts + 8 * 3600 * 1000);
   return d.getUTCFullYear() + '-' + String(d.getUTCMonth() + 1).padStart(2, '0') + '-' + String(d.getUTCDate()).padStart(2, '0');
 }
+const WEEKEND_OFFPEAK_FROM_MS = Date.UTC(2026, 7, 22, 16, 0, 0);
+function isWeekendOffPeak(nowMs) {
+  if (nowMs < WEEKEND_OFFPEAK_FROM_MS) return false;
+  const day = new Date(nowMs + 8 * 3600 * 1000).getUTCDay();
+  return day === 0 || day === 6;
+}
 function currentPeriod(nowMs) {
+  if (isWeekendOffPeak(nowMs)) return 'offpeak';
   const d = new Date(nowMs + 8 * 3600 * 1000);
   const m = d.getUTCHours() * 60 + d.getUTCMinutes();
   return (m >= 9 * 60 && m < 12 * 60) || (m >= 14 * 60 && m < 18 * 60) ? 'peak' : 'offpeak';

--- a/tests/test-weekend-offpeak.mjs
+++ b/tests/test-weekend-offpeak.mjs
@@ -1,0 +1,147 @@
+// 周末全天空闲价（端到端，桩环境，直接 import 源码）：
+// DeepSeek 官方自 2026-08-23（周日）00:00 北京时间起，周末（按北京日历的
+// 周六、周日）全天按空闲价计费，换算成 UTC 是 2026-08-22T16:00:00Z。
+// 这里通过真实的 getPricing RPC 打进 host.js 的 currentPeriod / nextSwitchAt，
+// 而不是在测试里另抄一份判定——抄一份就抓不到源码里的错。
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const tmpData = mkdtempSync(join(tmpdir(), 'bib-weekend-'))
+process.env.DSH_BOTTOM_INFO_BAR_DATA_DIR = tmpData
+process.env.DSH_BOTTOM_INFO_BAR_CODEX_AUTH = join(tmpData, 'no-codex-auth.json')
+process.env.DSH_BOTTOM_INFO_BAR_OPENCODE_AUTH = join(tmpData, 'no-opencode-auth.json')
+
+const plugin = (await import('../plugin/src/host.js')).default
+
+let failures = 0
+function check(name, cond, detail) {
+  if (cond) console.log('PASS  ' + name)
+  else { failures += 1; console.log('FAIL  ' + name + (detail ? ' — ' + detail : '')) }
+}
+
+globalThis.fetch = async () => ({ ok: true, status: 200, json: async () => ({ version: '0.0.0' }) })
+
+function makeStub() {
+  const captured = { route: null }
+  const ctx = {
+    get(name) {
+      if (name === 'agentDefaultModel') {
+        return { currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-v4-flash' }) }
+      }
+      return undefined
+    },
+    credentials: { resolve: async () => { throw new Error('no-key') } },
+    shell: { resolve: () => ({}), run: async () => ({ exitCode: 0, stdout: { text: '' } }) },
+    interval() { return () => {} },
+    timeout() { return () => {} },
+    on() { return () => {} },
+    inject(services, cb) {
+      cb({
+        effect(fn) { const d = fn(); return () => { if (typeof d === 'function') d() } },
+        webServer: { register(route) { captured.route = route; return () => {} } },
+      })
+      return () => {}
+    },
+  }
+  return { captured, ctx }
+}
+
+async function invoke(route, path) {
+  const listeners = {}
+  const req = { url: path, method: 'GET', headers: {}, on(ev, cb) { (listeners[ev] = listeners[ev] || []).push(cb); return req }, destroy() {} }
+  let status = 0
+  let payload = null
+  const res = { writeHead(s) { status = s }, end(b) { try { payload = JSON.parse(b) } catch { payload = String(b) } } }
+  const pending = route.handler(req, res)
+  for (const cb of listeners.end || []) cb()
+  await pending
+  return { status, payload }
+}
+
+const stub = makeStub()
+plugin.apply(stub.ctx)
+await new Promise((r) => setTimeout(r, 30))
+
+const realNow = Date.now
+/** 把时钟钉在某个 UTC 时刻，走一遍真正的 getPricing。 */
+async function pricingAt(iso) {
+  const fixed = Date.parse(iso)
+  Date.now = () => fixed
+  try {
+    return (await invoke(stub.captured.route, '/_dsh/dsh-bottom-info-bar/getPricing')).payload
+  } finally {
+    Date.now = realNow
+  }
+}
+
+// 北京星期，用来证明下面每个时刻确实落在注释说的那一天上。
+const WEEK = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
+function bjDay(iso) { return WEEK[new Date(Date.parse(iso) + 8 * 3600 * 1000).getUTCDay()] }
+
+// ---------- ① 生效后的周末，峰段时间也按空闲价 ----------
+{
+  check('2026-08-23T01:30Z 是北京周日', bjDay('2026-08-23T01:30:00Z') === '周日')
+  const p = await pricingAt('2026-08-23T01:30:00Z') // 周日 09:30 北京
+  check('周末 09:30 北京 → offpeak（旧代码在这里报 peak，按两倍价记账）',
+    p.period === 'offpeak', 'period=' + (p && p.period))
+  const q = await pricingAt('2026-08-29T07:00:00Z') // 周六 15:00 北京
+  check('2026-08-29T07:00Z 是北京周六', bjDay('2026-08-29T07:00:00Z') === '周六')
+  check('周末 15:00 北京 → offpeak', q.period === 'offpeak', 'period=' + (q && q.period))
+}
+
+// ---------- ② 工作日不受影响 ----------
+{
+  const p = await pricingAt('2026-08-24T01:30:00Z') // 周一 09:30 北京
+  check('2026-08-24T01:30Z 是北京周一', bjDay('2026-08-24T01:30:00Z') === '周一')
+  check('工作日 09:30 北京 → peak（原有行为不变）', p.period === 'peak', 'period=' + (p && p.period))
+  const q = await pricingAt('2026-08-24T05:00:00Z') // 周一 13:00 北京
+  check('工作日 13:00 北京 → offpeak（原有行为不变）', q.period === 'offpeak', 'period=' + (q && q.period))
+}
+
+// ---------- ③ 周末是北京的周末，不是 UTC 的 ----------
+// 北京的周末从周五 16:00 UTC 到周日 16:00 UTC。UTC 日历和北京日历只在
+// 16:00–24:00 UTC 这一段不一致，而两个峰段窗口都不在这一段里——所以拿
+// 未平移的 UTC 星期去判断，今天写什么用例都能过，等哪天峰段挪过 16:00
+// UTC 才开始出错。这两条钉的就是那条平移。
+{
+  const p = await pricingAt('2026-08-28T16:30:00Z') // UTC 周五，北京周六 00:30
+  check('2026-08-28T16:30Z 在 UTC 是周五，在北京是周六', bjDay('2026-08-28T16:30:00Z') === '周六')
+  check('UTC 周五 16:30 → 已进北京周末 → offpeak', p.period === 'offpeak', 'period=' + (p && p.period))
+  const q = await pricingAt('2026-08-23T16:00:00Z') // 北京周一 00:00 整
+  check('2026-08-23T16:00Z 是北京周一', bjDay('2026-08-23T16:00:00Z') === '周一')
+  check('周日 16:00 UTC 起就是北京周一，周末规则到此为止', q.period === 'offpeak' && q.mode === 'peak-valley')
+}
+
+// ---------- ④ 生效时刻之前，答案必须和从前一样 ----------
+{
+  check('2026-08-15T01:00Z 是北京周六', bjDay('2026-08-15T01:00:00Z') === '周六')
+  const p = await pricingAt('2026-08-15T01:00:00Z') // 新规生效前的周六 09:00 北京
+  check('新规生效前的周六 09:00 → 仍是 peak（回放旧账本不被改价）',
+    p.period === 'peak', 'period=' + (p && p.period))
+  const q = await pricingAt('2026-08-22T16:00:00Z') // 生效的第一毫秒
+  check('新规第一刻（北京周日 00:00）→ offpeak', q.period === 'offpeak', 'period=' + (q && q.period))
+}
+
+// ---------- ⑤ 倒计时不能承诺一个不会发生的切换 ----------
+{
+  const p = await pricingAt('2026-08-23T01:30:00Z') // 周日 09:30 北京
+  const hours = p.nextSwitch ? (p.nextSwitch.at - Date.parse('2026-08-23T01:30:00Z')) / 3600000 : null
+  check('周日 09:30 北京，下次切换是周一 09:00（23.5 小时后），不是 2.5 小时后',
+    p.nextSwitch && p.nextSwitch.atLabel === '09:00' && Math.abs(hours - 23.5) < 1e-6,
+    'atLabel=' + (p.nextSwitch && p.nextSwitch.atLabel) + ' hours=' + hours)
+  const q = await pricingAt('2026-08-28T10:30:00Z') // 周五 18:30 北京
+  const qh = q.nextSwitch ? (q.nextSwitch.at - Date.parse('2026-08-28T10:30:00Z')) / 3600000 : null
+  check('周五 18:30 北京，跨过整个周末，下次切换在 62.5 小时后的周一 09:00',
+    q.nextSwitch && q.nextSwitch.atLabel === '09:00' && Math.abs(qh - 62.5) < 1e-6,
+    'atLabel=' + (q.nextSwitch && q.nextSwitch.atLabel) + ' hours=' + qh)
+  const r = await pricingAt('2026-08-24T01:30:00Z') // 周一 09:30 北京
+  const rh = r.nextSwitch ? (r.nextSwitch.at - Date.parse('2026-08-24T01:30:00Z')) / 3600000 : null
+  check('工作日的倒计时一如从前：周一 09:30 → 2.5 小时后 12:00',
+    r.nextSwitch && r.nextSwitch.atLabel === '12:00' && Math.abs(rh - 2.5) < 1e-6,
+    'atLabel=' + (r.nextSwitch && r.nextSwitch.atLabel) + ' hours=' + rh)
+}
+
+rmSync(tmpData, { recursive: true, force: true })
+console.log(failures === 0 ? '结果：全部 PASS' : '结果：' + failures + ' FAIL')
+process.exit(failures === 0 ? 0 : 1)


### PR DESCRIPTION
## 问题

DeepSeek 已经改了峰谷计费规则：**北京时间周六、周日全天按空闲价**。官网原文（2026-08-22 读取）：

> Effective 00:00 (Beijing Time) on Sunday, August 23, 2026, we will adjust our peak/off-peak billing rules, with off-peak rates applying throughout the day on weekends.

> Off-peak rates are half of the peak rates.

现在 `host.js` 的峰谷判定只看一天里的分钟数，没有星期这一维，所以周末落在 09:00–12:00 / 14:00–18:00 的调用会被按**两倍价**记账，底栏也会显示成「高峰」。峰段窗口本身（北京 09:00–12:00、14:00–18:00）是对的，只有星期这一层缺失。

生效时刻换算成 UTC 是 `2026-08-22T16:00:00Z`。

## 改了什么

`plugin/src/host.js`：

- 新增 `WEEKEND_OFFPEAK_FROM_MS = Date.UTC(2026, 7, 22, 16, 0, 0)`；
- 新增 `isWeekendOffPeak(nowMs)`，`currentPeriod` 先问它；
- `nextSwitchAt` 改成一天一天往前找、跳过周末。

## 两个容易踩空的地方

**一、按生效时刻卡住，不追溯改价。** 账本里存的是历史请求，`costOf` 用的是 `record.ts` 而不是当下时间。如果无条件按周末打折，重启后重放旧账本，8 月之前那些周末的账会被悄悄改小。所以 `isWeekendOffPeak` 在生效时刻之前一律返回 `false`，旧账原样不动。

**二、周末是北京日历的周末，不是 UTC 日历的。** 北京的周末从周五 16:00 UTC 一直到周日 16:00 UTC。两个日历只在 16:00–24:00 UTC 这一段不一致，而现有的两个峰段窗口都不在这一段里——也就是说，直接对未平移的时间取 `getUTCDay()`，今天能写出来的用例全都能过，等哪天窗口挪过 16:00 UTC 才开始出错。所以星期几和分钟数从同一个平移过的时间上取（`beijingMinutes` 已经是这么做的）。测试里 `2026-08-28T16:30:00Z` 这条钉的就是这个：UTC 是周五，北京已经是周六 00:30。

## 一个行为变化，需要你拍板

`nextSwitchAt` 原来返回的时刻必定落在当天或次日 09:00，现在可能远到 60 多小时之外——周五 18:30 之后，下一次进高峰确实是周一早上 09:00。底栏那句倒计时会因此出现「62 小时后」这种读数。

我认为返回真实值是对的：返回一个当天的旧数字，等于承诺一个不会发生的切换。但如果你更想让文案短一点，我可以改成周末直接不显示倒计时，或者显示「周末全天空闲」。说一声我就改。

## 测试

新增 `tests/test-weekend-offpeak.mjs`，17 条断言，已挂进 `tests/run-all.mjs`。它不另抄一份判定逻辑，而是钉住 `Date.now()` 之后走真实的 `getPricing` RPC，读回 `period` 和 `nextSwitch`——抄一份就抓不到源码里的错。覆盖：周末峰段时间、工作日不受影响、北京 vs UTC 的周末边界、生效时刻前后、以及跨周末的倒计时。

`node tests/run-all.mjs` 全绿（改动前基线也是全绿）。

另外 `tests/test-spend-accounting.js` 里有一段手抄的记账逻辑，注释写着「与 host.js 逐行一致」，我同步更新了，好让那句话继续为真。顺带一提：这种手抄副本是抓不到 `host.js` 里的 bug 的——这次的周末漏判它就抓不到，改不改由你定，我没在这个修 bug 的 PR 里动你们的测试结构。
