### PR TITLE
fix(settings): blank settings page from React #310 hooks violation

### DIFF
--- a/plugin/src/client-settings.js
+++ b/plugin/src/client-settings.js
@@ -122,7 +122,7 @@ function bibSetSwitch(props) {
 // 色板圆点组：默认 + 预设色名；role=radiogroup/radio + roving tabindex（方向键/Home/End）
 function bibSetPalette(props) {
   const options = ['default'].concat(PRESET_COLORS);
-  const refs = React.useRef({});
+  const refs = { current: {} };
   const isSelected = function (option) {
     return option === 'default' ? props.value === null : props.value === option;
   };


### PR DESCRIPTION
## 问题

信息底栏设置页（设置 → 左侧「信息底栏」）显示为空白。

这在 #28 中被报告。根因不是数据错误——宿主 RPC 端点 `POST /_dsh/dsh-bottom-info-bar/getFieldConfig` 返回 200 且数据完整。实际是客户端渲染时抛错，被 DSH 设置面板的 `SlotErrorBoundary` 捕获后渲染成空 `<div data-slot-error>`，所以整页空白。

浏览器控制台报错：

```
[console.error] slot entry crashed in 'settings.section': Error: Minified React error #310
    at bibSetPalette (client.js:1506:22)
    at InfoBarSettingsSection (client.js:1761:11)
```

React **#310** = “Rendered more hooks than during the previous render”（渲染的 hook 数量与上一次不一致）。

## 根因（Rules of Hooks 违规）

`plugin/src/client-settings.js` 的 `bibSetPalette` 是**普通函数**，在 `InfoBarSettingsSection` 的字段渲染循环里被逐字段调用，但它内部调用了 `React.useRef({})`：

```js
function bibSetPalette(props) {
  const options = ['default'].concat(PRESET_COLORS);
  const refs = React.useRef({});   // ← 非组件里调用 hook
  ...
}
```

- 首次渲染走 `status === 'loading'` 分支（「正在载入信息底栏设置…」），只挂少量顶层 hooks。
- 配置拉回后进入 `status === 'ready'`，循环里对 `FIELD_REGISTRY`（27 个字段）逐字段调用 `bibSetPalette` → 这次渲染比上次**多出 27 次 `React.useRef` 调用**。

React 要求同一组件每次渲染 hook 的数量和顺序一致 → 抛出 **#310**。`bibSetPalette` 不是组件却用了 hook，违反 Rules of Hooks。

## 修复

把 `React.useRef({})` 换成普通闭包对象：

```js
function bibSetPalette(props) {
  const options = ['default'].concat(PRESET_COLORS);
  const refs = { current: {} };   // 普通闭包对象，不调用 hook
  ...
}
```

`refs.current[index] = node`（roving tabindex 的焦点逻辑）与 `refs.current[next]` 的用法保持完全一致，行为不变，只是不再在非组件里调用 hook，因此每次渲染的 hook 数量恒定。

## 验证

- 本地用无头 Edge（CDP）打开设置 → 点击「信息底栏」：`settings.section` 出口现在渲染出完整内容（`bib-set-root`、`显示字段`、`原生字段`、`轮次与步数` 等），不再是 `<div data-slot-error>`；`310 seen: false`。
- 全量测试 `node tests/run-all.mjs`：除 `test-field-settings` 的 `L1：journal 权限收敛为 0600` 外在 Windows 上既存失败（依赖 POSIX `chmod`，与本改动无关）外，其余 20 项全部 PASS，包括 `test-field-config-client` 与 `test-static-client`。

Closes #28（等维护者确认后）。
