### PR TITLE
ci(auto-merge): 僅 owner 的 PR 自動合併，他人手動

### DIFF
--- a/.github/workflows/auto-merge-own.yml
+++ b/.github/workflows/auto-merge-own.yml
@@ -1,0 +1,27 @@
+name: Auto-merge own PRs
+
+# 目標：只有倉庫擁有者 songoao25 的 PR 自動開啟 auto-merge（CI 通過後自動 squash），
+# 其他人（外部貢獻者 / fork）的 PR 保持手動，需人工 Review + 手動合併。
+# 這符合業界「trust-by-author」慣例：可信作者的 PR 自動化，不可信作者保留人工閘門。
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  enable-auto-merge:
+    # 只有 owner 的 PR 才進入；draft PR 不自動合
+    if: github.event.pull_request.user.login == 'songoao25' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge (squash) for owner PR
+        run: |
+          echo "Owner PR #${{ github.event.pull_request.number }} by ${{ github.event.pull_request.user.login }} → enable auto-merge (squash)"
+          gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
實現「自己的 PR 自動檢查自動合併，其他人的手動」

- 新增 `.github/workflows/auto-merge-own.yml`
- 觸發：`pull_request_target` + `pull_request` (opened/reopened/synchronize/ready_for_review)
- 條件：`github.event.pull_request.user.login == 'songoao25' && draft == false`
- 動作：`gh pr merge --auto --squash`，等待 `required_status_checks: [CI]` 綠後自動 squash 合併
- 外部貢獻者 PR 不符合條件→ 不會自動開 auto-merge，保留人工 Review + 手動合併，符合業界 trust-by-author 慣例
- 配合現有分支保護 `required_linear_history=true` 已生效