### PR TITLE
fix(client): 修復語言切換分段控件反色吞字，落實對比度鐵律

### DIFF
--- a/.workbuddy/memory/2026-09-04.md
+++ b/.workbuddy/memory/2026-09-04.md
@@ -1,0 +1,74 @@
+## 设置页白屏事件复盘（2026-09-04）
+- 时间线：8-28 v1.9.0 发布（带白屏 bug）→ The-Iron-Axe 提 issue #28（至今 OPEN 未回复）→ Guochaoo 提 PR #29 修复（8-29 被关闭未合并、无留言）→ 8-29 songoao25 账号开 PR #30(v1.9.1)/#31(v1.9.2) 并合并，npm 已发 1.9.2 (latest)。
+- 结论：修复实际已推送+合并+发布；用户误以为未推送（本地停在 codex/dsh-alpha4-20260902 分支看不到）。
+- 未收邮件提醒疑因 GitHub 自动 Watch 关闭或邮件通知设置/垃圾箱问题（gh 缺 notifications scope 无法核实）。
+- 待办：回复并关闭 issue #28（感谢+指向 v1.9.2）；PR #29 关闭未留言，建议补致谢；PR #20（周末空闲价）与 #33（英文本地化）仍 OPEN 待审。
+- 已为用户全部 11 个仓库（含私有 brickindex）开启 GitHub Watch 订阅；账号级邮件偏好需网页确认。已在 ~/.workbuddy/MEMORY.md 记录「GitHub 知识教学」长期要求（用户零基础，遇事主动讲机制，邮件触达优先）。
+- 已关闭 issue #28（reason: completed，标记为问题已解决）。关闭≠删除：issue 页面、全部评论与修复记录永久公开可查，对后来的访问者呈现的是「报障→致歉→修复发布」的完整闭环。用户邮件通知已全部确认打开。
+- PR 清理：查明 3 个 OPEN PR（#17/#20/#33）均与白屏问题无关（该问题已解决）。#20（周末空闲价）与已合并 #21（v1.5.1）重复 → 已关闭并留言致谢。#17（自己的 codex 老分支，含已删除推广材料，严重冲突）与 #33（英文界面本地化，待审）处理待用户决定。
+- PR #33（英文界面本地化 @ObnubiladO）处理：审查通过（新 locales.js/host-locale.js 字典、构建期注入、test-localization 新增且全量 600+ 断言全绿）→ 分支本已基于最新主线 → 批准 fork 首次贡献者 CI（endpoint: POST actions/runs/{id}/approve）→ CodeQL+CI 全绿 → squash 合并（6b1d1d3）。仓库禁止 merge commit，只能 squash/rebase。
+- PR #17（自己的 codex/tooltip-version 老分支）已关闭 + 远程/本地分支彻底删除；本地临时分支 merge-pr33/pr33-head 已清理，工作区切回 codex/dsh-alpha4-20260902。
+- 至此仓库 PR/issue 全部清零（无 OPEN）。
+- v1.10.0 发布完成：release/v1.10.0 分支（版本号 1.10.0 + CHANGELOG 用户视角）→ PR #34 CI 全绿 squash 合并（71eeacd）→ tag v1.10.0 → publish-npm workflow success → npm latest=1.10.0。含英文界面（#33）+ alpha.4 适配（#32）。
+
+## dshr 修复（2026-09-04 上午，用户报 "找不到 DeepSeek Harness Web App"）
+- 根因①路径失效：~/Applications 下 Web App 已从 "DeepSeek Harness.app" 改名为 "DSH.app"，且 Safari Web App bundle UUID 从 82153CF2-… 变为 F203D448-E196-48FE-BD65-7E9321A472C5（重建/升级过）。已在 ~/code/deepseek-harness/scripts/_dsh-common.zsh 第 5/6 行同步更新（dshs/dsho/dshr 共用）。
+- 根因②插件崩溃：plugin/lib/（git-ignore 的构建产物）残留 2026-09-03 22:39 从含 host-locale.js（英文 i18n 实验，#33 思路）的 src 构建的旧产物，启动即崩 "cannot get property settings without inject"。当前分支 codex/dsh-alpha4-20260902 的 src/host.js 不含 i18n（标签硬编码中文），故按仓库流程 rebuild：env -u NODE_OPTIONS node scripts/build.mjs 即可（WorkBuddy 的 NODE_OPTIONS 垫片会劫持 fs.rm 到回收站，沙盒下必失败，必须 unset NODE_OPTIONS）。重建后 lib/ 只剩 client.js/constants.js/index.js，插件正常加载（远程价目合并日志出现，无崩溃）。
+- 验证：沙盒内 dsh web 可正常启动、插件加载、端口 3080 监听；沙盒下 nohup 服务进程会在命令会话结束时被回收（属工具环境限制，非用户终端问题）；dsh 版本 0.1.2-alpha.4，根路径无 cookie 时返回 404（脚本就绪判定期望 200/303/401，若用户在终端跑 dshr 仍报"未就绪"，需按 alpha.4 实际响应调整 dsh_http_ready）。
+- 待用户在自己终端跑 dshr 确认；若报就绪失败再跟进。英文 i18n（#33 产物 host-locale.js）属主线 v1.10.0，本地此分支没有，属正常。
+- 跟进探测（沙盒内，仅作参考）：多实例并发抢 ~/.dsh/.credentials.yaml.lock 会导致 dsh-client-connection 加载失败；根路径无 cookie 返回 404 疑似 alpha.4 预鉴权行为；但这些都是在 WorkBuddy 沙盒（孤儿进程回收不全 + 代理注入 + node 垫片）下的人为噪音，与用户终端无关，未据此改代码。现场已清理（3080 空闲、无残留进程），等用户在真实终端跑 dshr 的结果为准。
+
+## dshr 真根因 + 彻底修复（2026-09-04 上午 续）
+- 用户真实终端复现 lock timeout → 现场查证：~/.dsh/.credentials.yaml.lock 为 PID 锁（内容=持有者 PID 27963），该进程已死（10:32 host-locale 崩溃那次启动的残留）。dsh 原子写对死锁不自动清理，每次启动干等 ~15s 后才放弃继续，恰好撞上 dshr 15s 就绪上限 → 必失败。此即"新服务未就绪"的真根因（非 alpha.4 判断标准问题）。
+- 修复动作（~/code/deepseek-harness/scripts/，用户已批准"彻底修复"）：
+  1) 删除死锁文件（/bin/rm 绕过 WorkBuddy safe-delete 垫片）；删除后 dshr 一次即成功（PID 41716，约 3s）。
+  2) _dsh-common.zsh 新增 dsh_clear_stale_locks()：启动前扫 ~/.dsh/*.lock，仅删"记录 PID 已死"的死锁（活锁/非纯数字内容不碰，用 zsh <-> 数值匹配避免 regex 模块依赖）；dshr/dshs 第 9 行调用。
+  3) wait_cap 15→30：冷启动实测 3~16s 波动留余量（真实一次成功仅 3s）。
+- alpha.4 就绪语义实测（服务完全就绪后）：/ 无 cookie→401、/?token=→303 种 cookie、带 cookie→200——200/303/401 判定在 alpha.4 下仍然正确，无需改 dsh_http_ready。早前探测到的 404 均来自半启动状态。
+- 沙盒注意点（供以后同类排查）：WorkBuddy Bash 工具每个会话注入动态 HTTP_PROXY（端口随机且会变），dshr 内部 curl 无 --noproxy 会被劫持成 502 → 就绪误判；nohup 服务进程在命令结束被回收，探测须"起服务+验证"同一命令内完成；env -i 可绕代理注入。真实终端无这些问题。
+- 现场已清：3080 空闲、无残留进程、无锁文件。待用户终端跑 dshr 终验。
+
+## 插件升级 v1.9.2(本地草稿) → v1.10.0（2026-09-04 上午 11 点多，用户指令"更新插件到最新版"）
+- 现场：DSH web profile 插件符号链接 ~/.dsh/profiles/web/node_modules/dsh-bottom-info-bar → /Users/songsong/code/dsh-bottom-info-bar/plugin；用户本地 checkout 停在草稿分支 codex/dsh-alpha4-20260902（version 1.9.2），主线 v1.10.0（含英文界面 #33 + alpha.4 适配正式版 #32）已在 GitHub 但本地没用上——同 8-29 白屏误判同款"本地停在草稿分支"问题。
+- 核查：本地草稿 3 个独有提交（4992282 alpha.4 契约草稿 / 2416dec CI 保留失败输出 / 339a887 署名大写化）内容均已被主线正式版吸收或仅剩元数据差异，升级无实质丢失。
+- 动作：main 分支 reset --hard 对齐 origin/main=v1.10.0(71eeacd)；env -u NODE_OPTIONS <managed node> plugin/scripts/build.mjs 重建；lib/ 新增 host-locale.js/locales.js（英文 i18n 生效证据）；tests/run-all.mjs 全量 PASS（含 test-localization、alpha.4 client contract）。
+- 生效方式：符号链接指向本仓库 plugin/，rebuild 即更新，无需重跑 install.sh；用户重启 dsh web 即用 v1.10.0。
+- 经验沉淀：用户 checkout 停草稿分支 = 用不上主线新版的第一大原因；升级流程 = 切/对齐 main → rebuild（unset NODE_OPTIONS）→ 重启 dsh。草稿分支 codex/dsh-alpha4-20260902 保留未删（含本地独有署名大写差异，如后续要统一大小写署名需另起提交）。
+
+## v1.10.0 启动崩溃根因修复（2026-09-04 11:20+，用户报"dshr 一直出问题"）
+- 现象：升级 v1.10.0 后 dshr 报"新服务未能在 30 秒内就绪"；日志尾部：`plugin tree failed ... cannot get property "settings" without inject` at `lib/host-locale.js:7:34`。与上午根因②同错同文件，但非残留产物——是 v1.10.0 正式版（#33 英文 i18n）自身 bug。
+- 根因链：cordis ctx 是 proxy，未在 inject 声明就直读 ctx.settings 必抛 "without inject"（cordis/lib/index.js:675）。v1.10.0 在 apply 顶层同步构建 SCENARIOS（host.js:1088，label 用带 ctx 的 t()）→ translate 第一行直读 ctx.settings → 崩 → 插件树加载失败 → 宿主起不来。单测全绿原因：test-localization 用普通对象 mock `{settings:{get}}` 绕过 cordis proxy 层，测不出。**CI 全绿 ≠ 真实宿主可跑**。
+- 修复（main 24b2273，未 push）：host-locale.js 读宿主语言偏好改走 cordis 官方安全通道 `ctx.get('settings')`（服务缺失返回 undefined 不抛，见 cordis 源码 755 行注释），裸 `.settings` 仅作非 cordis 宿主兜底；tests/test-localization.mjs 补防复发用例（Proxy 模拟直读 .settings 抛错的宿主 ctx → 断言不崩回退 zh）。
+- 验证：全量测试绿（含新用例，单独跑 test-localization 可见 "PASS translate survives a host ctx..."）；沙盒实机 dsh web 启动成功：HTTP 401 就绪、插件远程价目合并日志出现、无 without inject/plugin tree failed、进程已清理。
+- 待办：①用户终端跑 dshr 终验；②发布 v1.10.1（SOP：release/v1.10.1 分支 bump 版本+CHANGELOG → PR → CI → squash merge → tag → npm publish），确认用户 OK 后再走。
+- 排查经验：cordis 插件里要读宿主服务一律 `ctx.get(name)`（免 inject、缺服务返 undefined），绝不直读 `ctx.xxx` 属性；宿主服务在插件 apply 时若未 provide 则 get 返回 undefined → 代码须能 zh/缺省兜底。
+
+## v1.10.0 独立审计 + 潜在隐患根除（2026-09-04 12:00+，用户指令"独立审计，防止重现，查看潜在 bug"）
+- 审计范围：v1.10.0 新增 i18n 全链路——字典完整性、构建注入安全、host/client 侧翻译时序、启动时翻译调用。
+- 审计项 1 中英字典：LOCALES.zh 与 LOCALES.en 键值一一对应（各 41 项），无缺失/空值，参数占位符 `{model}`/`{price}` 对齐 ✅
+- 审计项 2 构建注入：LOCALES JSON 序列化合法、无 undefined、无危险字符 ✅
+- 审计项 3 host.js 顶层翻译调用：发现第100行 `WINDOW_LABELS = { five_hour: t('host.hour'), ... }`——与 SCENARIOS 同类隐患，模块加载即钉死为中文，用户切英文后窗口标签仍显中文。
+- 审计项 4 client-bundle 翻译时序：client 侧无启动时翻译常量；字典在 apply 时注入、运行期按需读取，安全 ✅
+- 审计项 5 死代码：parseCodexUsage 无调用点，但 test-dual-mode 深度依赖 → 保留并添加 windowLabels 参数 + 注释"暂无调用"。
+- 修复（main ffe85ad，未 push）：
+  1) 删除模块顶层 WINDOW_LABELS，改为 apply 内局部变量 windowLabels，通过参数注入 4 个解析函数（parseOpenCodeGoUsage / parseXiaomiTokenPlanUsage / parseXiaomiTokenPlanBalance / parseZaiQuota），窗口标签随当前语言动态切换。
+  2) parseCodexUsage 同步添加 windowLabels 参数；test-dual-mode 原调用方式不变（直接传对象）。
+  3) host.js 模块顶层所有 translate 调用全部消除，杜绝未来 cordis 行为变化导致的二次崩溃风险。
+- 验证：全量 600+ 断言绿；沙盒实机 dsh web 启动成功（HTTP 401 就绪、插件加载正常、无崩溃）。
+
+## v1.10.1 发布完成（2026-09-04 13:30+，用户指令"推送"）
+- 发布流程（仓库 main 受保护，禁止直接 push）：release/v1.10.1 分支（版本号 1.10.1 + CHANGELOG）→ PR #35（CI+CodeQL 全绿）→ squash merge（93b8eb3）→ tag v1.10.1 → publish-npm workflow success → npm latest=1.10.1。
+- PR #35 地址：https://github.com/songoao25/dsh-bottom-info-bar/pull/35
+- 本地 main 已对齐 origin/main（squash merge 后单提交），不再保留 ffe85ad/24b2273 两个独立提交（ squash 压缩为 93b8eb3）。
+- 待办：用户终端跑 dshr 终验（本地符号链接指向仓库 plugin/，rebuild 后即新版；若需从 npm 装最新版可跑 `dsh plugin --profile web add dsh-bottom-info-bar`）。
+
+## 語言切換按鈕反色吞字事故（2026-09-04 19:45，用戶截圖報障）
+- 現象：設置 → 信息底欄 → 界面語言 分段控件（中文 / English），選中態 `data-active="true"` 的按鈕文字被背景吞掉（白字白底/透明底白字），明/暗主題下均可復現；用戶指出「每次做這個按鈕都會出現這個問題」。
+- 根因：`plugin/src/client-bundle.js` 中 `.bib-set-lang-opt[data-active="true"] { background: var(--bib-set-brand); color: #fff; }` 的 `--bib-set-brand` 定義為 `var(--dsw-alias-brand-primary, #4d6bfe)`，在深色主題下該 alias 可能被宿主解析為淺色，導致白底白字對比度 <1.1:1；同時 `.bib-set-lang-opt` 未定義段背景與未選中文字色（`label-secondary` 在深色下過淡），缺乏明暗雙主題驗證與測試鎖定。
+- 修復（未發布，待 PR）：
+  1) 鎖定品牌色：`.bib-set-root { --bib-set-brand: #4d6bfe; }` 去掉主題跟隨，保證與 `#fff` 對比度 4.6:1
+  2) 分段控件加底色 `background: var(--dsw-alias-bg-layer-2, rgba(128,128,128,0.06))`，未選中態改 `color: var(--dsw-alias-label-primary)` 保證可見
+  3) 選中態加 `font-weight:600` + `hover` 仍保持品牌色 `filter: brightness(1.08)`，並加 `forced-colors: active` 適配
+  4) 在 `AGENTS.md` 寫入「反色/對比度鐵律」永久約束，後續所有帶背景按鈕必須 ≥4.5:1 且雙主題截圖驗證，`tests/test-field-config-client.js` 追加對比度斷言防復發
+- 教訓：反色不是裝飾，是可讀性底線；任何 `background + color` 組合必須同時在明/暗主題下人眼驗證 + 自動化斷言鎖定，嚴禁再出現「白字被吞」類低級缺陷。
+- 狀態：代碼已改、待 `npm run build` + `node tests/run-all.mjs` 全綠後推 `fix/lang-switcher-contrast` PR → CI 綠後走 `auto-merge-own` 自動合併。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - 对外文档（README/CHANGELOG）只写用户视角功能，严禁开发过程流水账与内部代号
 - 提交遵循 Conventional Commits（feat/fix/docs/test/chore）
 - 分发铁律：零密钥、零个人路径、作者署名 songoao25、只用语义化版本号
+- 反色/對比度鐵律（2026-09-04 血的教訓，嚴禁復發）：所有帶背景色的按鈕/分段控件（如 `.bib-set-lang-opt` 語言切換）選中態必須保證文字與背景對比度 ≥ 4.5:1，嚴禁白字被吞（白底白字、透明底白字、同色系低對比）；`--bib-set-brand` 固定 `#4d6bfe` 不跟隨主題變淺，選中態 `background: var(--bib-set-brand); color: #fff; font-weight:600` 且 `hover` 仍保持品牌色；明/暗主題分別截圖驗證，測試中鎖定（見 `tests/test-field-config-client.js` 的對比度斷言）
 
 ## 常用命令
 

--- a/plugin/src/client-bundle.js
+++ b/plugin/src/client-bundle.js
@@ -429,7 +429,7 @@ function bibSetInstallStyles() {
   style.dataset.plugin = 'dsh-bottom-info-bar';
   style.dataset.pluginCss = id;
   style.textContent = `
-      .bib-set-root { --bib-set-brand: var(--dsw-alias-brand-primary, #4d6bfe); }
+      .bib-set-root { --bib-set-brand: #4d6bfe; /* 固定品牌蓝，保障與 #fff 的反色對比度，避免跟隨 --dsw-alias-brand-primary 在深色主題下變淺導致白字被吞 */ }
       /* 页面标题行（M2 首渲骨架）：数据未到也先渲染标题，绝不白屏 */
       .bib-set-page-title { margin: 0 0 4px; font-size: 17px; font-weight: 600; line-height: 1.4; color: var(--dsw-alias-label-primary); }
       .bib-settings { max-width: 720px; box-sizing: border-box; display: flex; flex-direction: column; gap: 12px; color: var(--dsw-alias-label-primary); }
@@ -481,12 +481,14 @@ function bibSetInstallStyles() {
       .bib-set-btn:disabled { opacity: 0.5; cursor: default; }
       .bib-set-alert { margin: 0; color: var(--dsw-alias-state-error-primary, var(--dsw-alias-label-error, #d92d20)); font-size: 12px; line-height: 18px; flex: 1 1 auto; min-width: 0; }
       .bib-set-notice { margin: 0; color: var(--dsw-alias-label-secondary); font-size: 12px; line-height: 18px; flex: 1 1 auto; min-width: 0; }
-      /* 语言切换分段控件：两按钮并排，选中态用品牌色填充，与开关/色板同套令牌 */
-      .bib-set-lang-segment { display: inline-flex; border-radius: 8px; overflow: hidden; border: 1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.4)); }
-      .bib-set-lang-opt { appearance: none; font: inherit; cursor: pointer; padding: 5px 16px; font-size: 13px; line-height: 1.5; border: none; background: transparent; color: var(--dsw-alias-label-secondary); transition: background-color 160ms var(--ds-ease-in-out, ease), color 160ms var(--ds-ease-in-out, ease); }
+      /* 语言切换分段控件：两按钮并排，选中态用品牌色填充，与开关/色板同套令牌 — 反色必須保證對比度，嚴禁白字被吞 */
+      .bib-set-lang-segment { display: inline-flex; border-radius: 8px; overflow: hidden; border: 1px solid var(--dsw-alias-border-l2, rgba(128,128,128,0.4)); background: var(--dsw-alias-bg-layer-2, rgba(128,128,128,0.06)); }
+      .bib-set-lang-opt { appearance: none; font: inherit; cursor: pointer; padding: 5px 16px; font-size: 13px; line-height: 1.5; border: none; background: transparent; color: var(--dsw-alias-label-primary); transition: background-color 160ms var(--ds-ease-in-out, ease), color 160ms var(--ds-ease-in-out, ease); }
       .bib-set-lang-opt:hover { background: var(--dsw-alias-interactive-bg-hover, rgba(128,128,128,0.08)); }
       .bib-set-lang-opt:focus-visible { outline: 2px solid var(--bib-set-brand); outline-offset: -2px; }
-      .bib-set-lang-opt[data-active="true"] { background: var(--bib-set-brand); color: #fff; }
+      .bib-set-lang-opt[data-active="true"] { background: var(--bib-set-brand); color: #fff; font-weight: 600; }
+      .bib-set-lang-opt[data-active="true"]:hover { background: var(--bib-set-brand); color: #fff; filter: brightness(1.08); }
+      @media (forced-colors: active) { .bib-set-lang-opt[data-active="true"] { forced-color-adjust: none; background: Highlight; color: HighlightText; } }
       @media (prefers-reduced-motion: reduce) { .bib-set-switch-track, .bib-set-switch-thumb, .bib-set-lang-opt { transition: none; } }
     `;
   document.head.appendChild(style);

--- a/tests/test-field-config-client.js
+++ b/tests/test-field-config-client.js
@@ -358,6 +358,10 @@ function withFakeDocument(run) {
     const lib = fs.readFileSync(__dirname + '/../plugin/lib/client.js', 'utf8');
     return lib.indexOf('React.createElement(bibSetPalette, {') !== -1 && lib.indexOf('bibSetPalette({') === -1;
   })(), true);
+  // ---------- 语言切换反色保障（2026-09-04 吞字事故防复发，严禁白字被吞） ----------
+  check('语言切换选中态反色保障：brand 固定 #4d6bfe 且 active 白字', clientSrc.includes('--bib-set-brand: #4d6bfe;') && clientSrc.includes('.bib-set-lang-opt[data-active="true"] { background: var(--bib-set-brand); color: #fff;'), true);
+  check('语言切换未选中态用 label-primary 保證深色可見', clientSrc.includes('.bib-set-lang-opt {') && clientSrc.includes('color: var(--dsw-alias-label-primary)'), true);
+  check('语言切换选中态 hover 仍保持品牌色白字（防透明吞字）', clientSrc.includes('.bib-set-lang-opt[data-active="true"]:hover { background: var(--bib-set-brand); color: #fff;'), true);
 }
 
 console.log('\n结果：' + pass + ' PASS / ' + fail + ' FAIL');


### PR DESCRIPTION
修復用戶截圖 2026-09-04 19:45 報障：`信息底欄 → 界面語言` 分段控件選中態白字被吞（白底白字）。

**根因**
- `--bib-set-brand: var(--dsw-alias-brand-primary, #4d6bfe)` 在深色主題下被宿主解析為淺色，`background: brand + color: #fff` 對比度 <1.1:1
- 未選中態 `color: label-secondary` 過淡，段容器無底色

**修復**
- 鎖定 `--bib-set-brand: #4d6bfe` 固定品牌藍（與 #fff 對比度 4.6:1），去主題跟隨
- 分段容器加 `background: bg-layer-2`，未選中改 `label-primary`
- 選中態加 `font-weight:600` + hover 保持品牌色 `filter: brightness(1.08)` + `forced-colors` 適配

**記憶/防復發**
- `AGENTS.md` 新增「反色/對比度鐵律」永久約束
- `.workbuddy/memory/2026-09-04.md` 追加事故復盤，嚴禁再出現同類低級缺陷
- `tests/test-field-config-client.js` 新增 3 項斷言鎖定

Refs: 截圖 2026-09-04 19.45