### PR TITLE
ci(release): 全自动发版 — fix 合并即自动 bump + CHANGELOG + tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,16 @@
+name: Release Please
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        with:
+          release-type: node
+          path: plugin
+          package-name: dsh-bottom-info-bar


### PR DESCRIPTION
为 **全自动** 落实「每修必发」：

- 合到 `main` 的 `fix:` 自動 `patch`、`feat:` 自動 `minor`，機器人自動產生 `Release PR`（含 `CHANGELOG`）
- 該 Release PR 為 `owner` 所開，命中已有的 `auto-merge-own`（`user==owner`）→ `CI` 綠後自動合併 → 自動打 `tag` → 觸發已有 `publish-npm`（`v*.*.*`）或 `simple` 發布
- `brickindex` 用 `simple`（僅 GitHub 發版，不發 npm），其餘 `node`（含 `plugin` 路徑）