### PR TITLE
fix(ci): use a safe root changelog path for Release Please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "packages": {
     "plugin": {
       "package-name": "dsh-bottom-info-bar",
-      "changelog-path": "../CHANGELOG.md"
+      "changelog-path": "/CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
## What changed
Release Please now targets the repository-root changelog with the supported `/CHANGELOG.md` path form.

## Why
The previous `../CHANGELOG.md` form was rejected by the current Release Please action as illegal path traversal, so the workflow failed before it could create a release PR.

## Verification
- JSON configuration parses successfully.
- `git diff --check` passes.
- The next main-branch run will provide the remote Release Please verification.