### PR TITLE
fix(host): attribute session spend by DSH lineage

### DIFF
--- a/plugin/src/host.js
+++ b/plugin/src/host.js
@@ -1,7 +1,7 @@
 // Bottom Info Bar（底部信息栏插件）— host half（静态 bundle 形态）
 // 业务：余额真实 API / 峰谷定价 / llm/stream 记账 / 会话聚合 / 显示名识别 / 订阅额度显示
 // RPC：webServer HTTP 路由（GET/POST /_dsh/dsh-bottom-info-bar/<method>，JSON 进出，同源防护）
-// 依赖：inject ['credentials', 'timer']；可选服务 webServer（ctx.inject 等待）
+// 依赖：inject ['credentials', 'timer']；可选服务 webServer / sessionController（按能力读取）
 // 记账持久化：追加账本 + 可恢复快照落盘 ~/.dsh/dsh-bottom-info-bar/（可用环境变量
 // DSH_BOTTOM_INFO_BAR_DATA_DIR 覆盖目录），重启/中断后真实累计花费不丢失。
 // 订阅额度：本插件只读令牌（~/.codex/auth.json / opencode auth.json）查询额度、仅作显示；
@@ -817,6 +817,8 @@ export const __usageInternals = {
     aggregatesVersion: 0,
   },
   reset: resetUsageInternals,
+  normalizeSessionId: normalizeSessionIdValue,
+  sessionLineageIds: sessionLineageIds,
 }
 
 // ---------- v1.9.0 PR2：settings.json（字段显隐/颜色/信息密度）读写 ----------
@@ -986,6 +988,40 @@ function hardenLedgerFilePermissions() {
   } catch (err) { /* 尽力而为，不因权限问题崩溃 */ }
 }
 
+// DSH 的 sessionController 在宿主侧提供冷安全的会话摘要。这里仍接受
+// id/parentId 两种字段名，方便和不同版本的宿主/测试桩对接。
+function normalizeSessionIdValue(id) {
+  if (!id) return ''
+  return String(id).replace(/^session-/, '')
+}
+
+function sessionLineageIds(entries, rootSessionId) {
+  const root = normalizeSessionIdValue(rootSessionId)
+  const owned = new Set(root ? [root] : [])
+  if (!root || !Array.isArray(entries)) return owned
+  const childrenByParent = new Map()
+  for (const entry of entries) {
+    if (!entry || entry.origin !== 'subagent') continue
+    const id = normalizeSessionIdValue(entry.sessionId != null ? entry.sessionId : entry.id)
+    const parent = normalizeSessionIdValue(entry.parentSessionId != null ? entry.parentSessionId : entry.parentId)
+    if (!id || !parent) continue
+    const children = childrenByParent.get(parent) || []
+    children.push(id)
+    childrenByParent.set(parent, children)
+  }
+  const pending = [root]
+  while (pending.length > 0) {
+    const parent = pending.shift()
+    const children = childrenByParent.get(parent) || []
+    for (const child of children) {
+      if (owned.has(child)) continue
+      owned.add(child)
+      pending.push(child)
+    }
+  }
+  return owned
+}
+
 export const __settingsInternals = {
   // 测试/诊断专用：不参与任何业务判定
   sanitizeSettings: sanitizeSettings,
@@ -1009,6 +1045,51 @@ export default {
     const windowLabels = { five_hour: t('host.hour'), seven_day: t('ui.weekly'), monthly: t('ui.monthly') };
     // 版本检查只在 host 进程启动时发起一次；客户端后续只读取这个缓存结果。
     const updateInfoPromise = checkLatestVersion()
+    // 会话谱系列表是冷安全读取，但仍可能触发持久化查询；短暂缓存避免信息栏轮询
+    // 每次都重新扫描全部会话。缓存失效时再次读取，保证新建子代理最终能被纳入。
+    const SESSION_LINEAGE_CACHE_MS = 1000
+    let sessionLineageCache = { items: null, expiresAt: 0, pending: null }
+    let sessionLineageWarningShown = false
+
+    function sessionControllerForLineage() {
+      try {
+        if (ctx.get) {
+          const service = ctx.get('sessionController')
+          if (service && typeof service.list === 'function') return service
+        }
+      } catch (err) { /* 老版本宿主没有该可选服务，退回精确主会话 */ }
+      const direct = ctx.sessionController
+      if (direct && typeof direct.list === 'function') return direct
+      return null
+    }
+
+    async function readSessionLineageItems() {
+      const controller = sessionControllerForLineage()
+      if (!controller) return null
+      const now = Date.now()
+      if (sessionLineageCache.expiresAt > now) return sessionLineageCache.items
+      if (sessionLineageCache.pending) return sessionLineageCache.pending
+      sessionLineageCache.pending = (async function () {
+        try {
+          const signal = typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+            ? AbortSignal.timeout(1500)
+            : undefined
+          const result = signal === undefined ? await controller.list({}) : await controller.list({}, signal)
+          const items = Array.isArray(result) ? result : (result && Array.isArray(result.items) ? result.items : null)
+          if (!items) throw new Error('sessionController.list returned no items')
+          sessionLineageCache = { items: items, expiresAt: Date.now() + SESSION_LINEAGE_CACHE_MS, pending: null }
+          return items
+        } catch (err) {
+          sessionLineageCache = { items: null, expiresAt: Date.now() + SESSION_LINEAGE_CACHE_MS, pending: null }
+          if (!sessionLineageWarningShown) {
+            sessionLineageWarningShown = true
+            console.warn('[dsh-bottom-info-bar] session lineage unavailable; current-session totals use the selected session only: ' + String((err && err.message) || err))
+          }
+          return null
+        }
+      })()
+      return sessionLineageCache.pending
+    }
 
     // ---------- 定价表（元/美元 · 百万 tokens；来源与人工复核规则见 docs/PRICING-SOURCES.md） ----------
     const PRICING = {
@@ -2277,7 +2358,6 @@ export default {
       foldedUpTo: null, // 折叠边界（北京日起点 ms）；null = 从未折叠
       dayBuckets: {},   // day → account → currency → bucket
       sessions: {},     // accountKey\0sessionKey → { sessionId, account, input, cacheRead, cacheWrite, output, costs, minTs, maxTs }
-      sessionStarts: {}, // normalizeSessionId → minTs（跨账户取最小，本会话语义的 O(1) 起点）
       accountTotals: {}, // account → Σ costOf（币种混算，保持旧 providerSpend 口径）
     };
     let foldedSessionsDelta = {}; // 折叠记录的会话增量（持久化于 summaries；与明细重建部分不相交）
@@ -2355,12 +2435,6 @@ export default {
       }
       if (record.ts < entry.minTs) entry.minTs = record.ts;
       if (record.ts > entry.maxTs) entry.maxTs = record.ts;
-      // 本会话起点 = 该归一化 sessionId 的最早记录（跨账户取最小，与旧全扫口径一致）
-      const norm = normalizeSessionId(record.sessionId);
-      if (norm) {
-        const known = summariesState.sessionStarts[norm];
-        if (known == null || record.ts < known) summariesState.sessionStarts[norm] = record.ts;
-      }
     }
 
     // 记账 O(1) 路径：push 后增量更新当日桶 + 会话索引 + 账户累计器
@@ -2425,7 +2499,6 @@ export default {
       summariesState.foldedUpTo = boundary;
       summariesState.dayBuckets = {};
       summariesState.sessions = {};
-      summariesState.sessionStarts = {};
       summariesState.accountTotals = {};
       if (fileSummaries) {
         for (const day of Object.keys(fileSummaries.foldedDayBuckets)) {
@@ -2454,11 +2527,6 @@ export default {
             minTs: Number(entry.minTs) || 0,
             maxTs: Number(entry.maxTs) || 0,
           };
-          const norm = normalizeSessionId(entry.sessionId);
-          if (norm) {
-            const known = summariesState.sessionStarts[norm];
-            if (known == null || entry.minTs < known) summariesState.sessionStarts[norm] = entry.minTs;
-          }
         }
         for (const key of Object.keys(fileSummaries.foldedAccountTotals)) {
           summariesState.accountTotals[safeMapKey(key)] = Number(fileSummaries.foldedAccountTotals[key]) || 0;
@@ -3039,66 +3107,32 @@ export default {
       };
     }
 
-    // 会话 ID 归一化：DSH 部分路径会给 sessionId 加 'session-' 前缀，去掉后统一比较
-    function normalizeSessionId(id) {
-      if (!id) return '';
-      return String(id).replace(/^session-/, '');
-    }
-
-    // v1.7（发布前微调）：本会话聚合含子代理花费——从"按 sessionId 精确匹配"改为
-    // "会话起点 = 当前 sessionId 的最早记录时间戳；聚合同账户（recordAccount === activeAccount）
-    //  且 ts >= 会话起点的全部记录"——子代理/同账户不同 sessionId 的并行记录自然被纳入。
-    // 未知账户（activeAccount=null）时匹配无主记录（recordAccount 同为 null），绝不混入其他账户。
-    // v1.9：起点由会话索引 O(1) 取得；起点之后的天读日桶，起点当天（边界天）在明细上
-    // 二分后逐条过滤 r.ts >= start——边界天不读桶、桶不含边界天，与旧两遍全扫逐字段等价。
-    // 例外（退化）：起点早于 90 天折叠窗时边界天的 priced 明细已折叠，只能整天读桶，
-    // 无法再剔除起点之前的同日同账户记录（见 docs/PERF-AUDIT-v1.9.md §⑤ 风险表）。
-    function accumulateBucketDay(acc, day, accountKey) {
-      const dayBuckets = summariesState.dayBuckets[day];
-      const accountBuckets = dayBuckets && dayBuckets[accountKey];
-      if (!accountBuckets) return;
-      for (const currency of Object.keys(accountBuckets)) {
-        const bucket = accountBuckets[currency];
-        acc.input += bucket.input;
-        acc.cacheRead += bucket.cacheRead;
-        acc.cacheWrite += bucket.cacheWrite;
-        acc.output += bucket.output;
-        if (bucket.records > 0) acc.costs[currency] = (acc.costs[currency] || 0) + bucket.cost;
-      }
-    }
-
-    function currentSessionSummary(activeAccount, sessionId) {
+    // Issue #44：本会话只聚合当前会话及 DSH 明确标记为 origin=subagent 的后代。
+    // 旧实现用“当前会话最早时间 + 同账户后续所有记录”推测子代理，会把并行的其他会话
+    // 一并算进来；没有 sessionController 的老宿主则安全退回“只算选中会话”，绝不猜测。
+    async function currentSessionSummary(activeAccount, sessionId) {
       if (usageRecords.length === 0) return null;
       if (!sessionId) return null; // 无可用会话 ID：不猜测归属，客户端显示 ¥0.000，而非回退最近会话
-      const norm = normalizeSessionId(sessionId);
-      const sessionStart = summariesState.sessionStarts[norm];
-      if (sessionStart == null) return null; // 明确传入但未命中（新会话尚无记账）→ 客户端显示 ¥0.000
-      const accountKey = accountBucketKey(activeAccount);
+      const norm = normalizeSessionIdValue(sessionId);
+      if (!norm) return null;
+      const lineageItems = await readSessionLineageItems();
+      const ownedSessionIds = lineageItems ? sessionLineageIds(lineageItems, norm) : new Set([norm]);
       const acc = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0, costs: {} };
-      const boundaryDay = beijingDayKey(sessionStart);
-      const boundaryStartMs = beijingDayStartMs(boundaryDay);
-      if (summariesState.foldedUpTo == null || boundaryStartMs >= summariesState.foldedUpTo) {
-        // 边界天仍在保留窗内：明细完整，逐条过滤（ts 有序 → 二分定位，只扫边界天）
-        scanDetailRange(boundaryStartMs, boundaryStartMs + MS_PER_DAY, function (r) {
-          if (r.ts < sessionStart) return;
-          if (recordAccount(r) !== activeAccount) return; // 只聚合当前账户（含无主 null 账户匹配）
-          acc.input += r.input;
-          acc.cacheRead += r.cacheRead;
-          acc.cacheWrite += r.cacheWrite;
-          acc.output += r.output;
-          const c = costOf(r, false);
-          if (c != null) {
-            const cur = recordCurrency(r);
-            acc.costs[cur] = (acc.costs[cur] || 0) + c;
-          }
-        });
-      } else {
-        accumulateBucketDay(acc, boundaryDay, accountKey);
+      let matched = false;
+      for (const key of Object.keys(summariesState.sessions)) {
+        const entry = summariesState.sessions[key];
+        if (!entry || entry.account !== activeAccount) continue;
+        if (!ownedSessionIds.has(normalizeSessionIdValue(entry.sessionId))) continue;
+        matched = true;
+        acc.input += entry.input;
+        acc.cacheRead += entry.cacheRead;
+        acc.cacheWrite += entry.cacheWrite;
+        acc.output += entry.output;
+        for (const currency of Object.keys(entry.costs || {})) {
+          acc.costs[currency] = (acc.costs[currency] || 0) + (Number(entry.costs[currency]) || 0);
+        }
       }
-      for (const day of Object.keys(summariesState.dayBuckets)) {
-        if (day <= boundaryDay) continue;
-        accumulateBucketDay(acc, day, accountKey);
-      }
+      if (!matched) return null; // 明确传入但未命中（新会话尚无记账）→ 客户端显示 ¥0.000
       const denom = acc.input + acc.cacheRead + acc.cacheWrite;
       return {
         input: acc.input,
@@ -3336,9 +3370,9 @@ export default {
     }
 
     // ---------- 用量汇总 ----------
-    // v1.9：全部字段由日桶/会话索引组装（O(桶数+会话数)+边界天扫描），明细遍历只剩
-    // “当前会话边界天 + 各滚动窗截止日”，不再随总记录数增长
-    function getUsageSummary(nowMs, sessionId, selection) {
+    // v1.9：全部字段由日桶/会话索引组装（O(桶数+会话数)+边界天扫描）；本会话改为
+    // 会话索引 + DSH 谱系读取，各滚动窗仍只扫描截止日，不再随总记录数增长。
+    async function getUsageSummary(nowMs, sessionId, selection) {
       const sel = selection || modelSelection();
       // v1.6：计算当前活跃账户，用于会话聚合过滤
       const activeAccount = accountForProvider(sel.provider);
@@ -3346,7 +3380,7 @@ export default {
       return {
         sessions: sessions.length,
         calibration: calibrationFrom(sessions, CALIB_SESSIONS),
-        currentSession: currentSessionSummary(activeAccount, sessionId),
+        currentSession: await currentSessionSummary(activeAccount, sessionId),
         spend: spendSummary(nowMs, selection),
         todaySpend: todaySpend(nowMs, selection),
         monthSpend: monthSpend(nowMs, selection),
@@ -3445,7 +3479,7 @@ export default {
       getEstimate: function () {
         return computeEstimate(Date.now());
       },
-      getUsageSummary: function (args) {
+      getUsageSummary: async function (args) {
         const sessionId = args && typeof args === 'object' ? String(args.sessionId || '') : '';
         return getUsageSummary(Date.now(), sessionId, selectionFromArgs(args));
       },

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -33,6 +33,7 @@ const cases = [
   ['test-dual-mode（host.js 双模式逻辑 + client 订阅渲染）', ['tests/test-dual-mode.js'], join(root), process.execPath],
   ['test-usage-sanitize（host.js 记账数值清洗）', ['tests/test-usage-sanitize.js'], join(root), process.execPath],
   ['test-usage-ledger（耐久账本与历史价格）', ['tests/test-usage-ledger.mjs'], join(root), process.execPath],
+  ['test-session-lineage（Issue #44 父子会话精确归属）', ['tests/test-session-lineage.mjs'], join(root), process.execPath],
   ['test-usage-compaction（v1.9 压缩等价/会话锁/回填/扫描量/崩溃安全）', ['tests/test-usage-compaction.mjs'], join(root), process.execPath],
   ['test-field-settings（v1.9 PR2 设置落盘/白名单/密度持久/双重置/configVersion）', ['tests/test-field-settings.mjs'], join(root), process.execPath],
   ['test-field-config-client（v1.9 PR2 客户端过滤/零回归着色/注册表一致性）', ['tests/test-field-config-client.js'], join(root), process.execPath],

--- a/tests/test-session-lineage.mjs
+++ b/tests/test-session-lineage.mjs
@@ -1,0 +1,88 @@
+// Issue #44：本会话花费必须只包含选中会话及 DSH 明确标记的子代理后代。
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+const dataDir = mkdtempSync(join(tmpdir(), 'bib-lineage-'))
+process.env.DSH_BOTTOM_INFO_BAR_DATA_DIR = dataDir
+process.env.DSH_BOTTOM_INFO_BAR_CODEX_AUTH = join(dataDir, 'no-codex.json')
+process.env.DSH_BOTTOM_INFO_BAR_OPENCODE_AUTH = join(dataDir, 'no-opencode.json')
+globalThis.fetch = async () => ({ ok: false, status: 404, json: async () => ({}) })
+
+const records = [
+  { id: 'root-call', ts: 1787000000000, model: 'deepseek-chat', provider: 'deepseek', sessionId: 'root', input: 10, cacheRead: 0, cacheWrite: 0, output: 1, currency: 'CNY', cost: 1 },
+  { id: 'child-call', ts: 1787000000001, model: 'deepseek-chat', provider: 'deepseek', sessionId: 'child', input: 20, cacheRead: 0, cacheWrite: 0, output: 2, currency: 'CNY', cost: 2 },
+  { id: 'grandchild-call', ts: 1787000000002, model: 'deepseek-chat', provider: 'deepseek', sessionId: 'grandchild', input: 30, cacheRead: 0, cacheWrite: 0, output: 3, currency: 'CNY', cost: 3 },
+  { id: 'other-call', ts: 1787000000003, model: 'deepseek-chat', provider: 'deepseek', sessionId: 'other', input: 40, cacheRead: 0, cacheWrite: 0, output: 4, currency: 'CNY', cost: 4 },
+  { id: 'other-child-call', ts: 1787000000004, model: 'deepseek-chat', provider: 'deepseek', sessionId: 'other-child', input: 50, cacheRead: 0, cacheWrite: 0, output: 5, currency: 'CNY', cost: 5 },
+  { id: 'fork-call', ts: 1787000000005, model: 'deepseek-chat', provider: 'deepseek', sessionId: 'fork', input: 60, cacheRead: 0, cacheWrite: 0, output: 6, currency: 'CNY', cost: 6 },
+]
+writeFileSync(join(dataDir, 'usage-records.json'), JSON.stringify(records))
+
+const lineage = [
+  { sessionId: 'root' },
+  { sessionId: 'session-child', parentSessionId: 'session-root', origin: 'subagent' },
+  { sessionId: 'grandchild', parentSessionId: 'child', origin: 'subagent' },
+  { sessionId: 'other' },
+  { sessionId: 'other-child', parentSessionId: 'other', origin: 'subagent' },
+  // A parent field without the durable subagent marker is intentionally excluded.
+  { sessionId: 'fork', parentSessionId: 'root' },
+  // Cycles must not make lineage expansion loop forever.
+  { sessionId: 'cycle-a', parentSessionId: 'cycle-b', origin: 'subagent' },
+  { sessionId: 'cycle-b', parentSessionId: 'cycle-a', origin: 'subagent' },
+]
+
+const mod = await import('../plugin/src/host.js?lineage=' + encodeURIComponent(dataDir))
+const plugin = mod.default
+let listCalls = 0
+const captured = { route: null }
+const ctx = {
+  get(name) {
+    if (name === 'agentDefaultModel') return { currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-chat' }) }
+    if (name === 'sessionController') return { list: async () => { listCalls += 1; return { items: lineage } } }
+    return undefined
+  },
+  credentials: { resolve: async () => null },
+  interval() { return () => {} },
+  timeout() { return () => {} },
+  on() { return () => {} },
+  inject(services, callback) {
+    callback({ effect(fn) { const dispose = fn(); return () => dispose && dispose() }, webServer: { register(route) { captured.route = route; return () => {} } } })
+    return () => {}
+  },
+}
+
+async function invoke(sessionId) {
+  const listeners = {}
+  const req = { url: '/_dsh/dsh-bottom-info-bar/getUsageSummary', method: 'POST', headers: {}, on(name, listener) { (listeners[name] ||= []).push(listener); return req }, destroy() {} }
+  let payload = null
+  const pending = captured.route.handler(req, { writeHead() {}, end(text) { payload = JSON.parse(text) } })
+  for (const listener of listeners.data || []) listener(Buffer.from(JSON.stringify({ sessionId, selection: { provider: 'deepseek', model: 'deepseek-chat' } })))
+  for (const listener of listeners.end || []) listener()
+  await pending
+  return payload
+}
+
+let failures = 0
+function check(name, condition, detail) {
+  if (condition) console.log('PASS  ' + name)
+  else { failures += 1; console.log('FAIL  ' + name + (detail ? ' — ' + JSON.stringify(detail) : '')) }
+}
+
+const pureIds = [...mod.__usageInternals.sessionLineageIds(lineage, 'root')].sort()
+check('谱系只包含根会话和 origin=subagent 后代', JSON.stringify(pureIds) === JSON.stringify(['child', 'grandchild', 'root']), pureIds)
+check('循环谱系不会把无关会话带入', !mod.__usageInternals.sessionLineageIds(lineage, 'root').has('cycle-a'))
+
+const dispose = plugin.apply(ctx)
+const root = await invoke('session-root')
+const child = await invoke('child')
+const other = await invoke('other')
+check('主会话包含子代理和孙代理', root.currentSession && root.currentSession.tokens === 66 && root.currentSession.costs.CNY === 6, root.currentSession)
+check('主会话不包含同账户其他会话或未标记 fork', root.currentSession && root.currentSession.tokens !== 165 && root.currentSession.costs.CNY !== 15, root.currentSession)
+check('子代理只包含自己及其后代', child.currentSession && child.currentSession.tokens === 55 && child.currentSession.costs.CNY === 5, child.currentSession)
+check('另一个根会话拥有自己的子代理', other.currentSession && other.currentSession.tokens === 99 && other.currentSession.costs.CNY === 9, other.currentSession)
+check('短缓存避免一次汇总轮询重复读取会话列表', listCalls === 1, { listCalls })
+dispose()
+rmSync(dataDir, { recursive: true, force: true })
+console.log(failures === 0 ? '\n结果：全部 PASS' : '\n结果：' + failures + ' 项 FAIL')
+process.exit(failures === 0 ? 0 : 1)

--- a/tests/test-spend-accounting.js
+++ b/tests/test-spend-accounting.js
@@ -99,8 +99,7 @@ function sessionTotals() {
   return Array.from(map.values()).sort(function (a, b) { return a.lastTs - b.lastTs; });
 }
 
-// ---- v1.7 本会话聚合（含子代理）复刻——与 host.js currentSessionSummary 逐行一致：
-// 会话起点 = 当前 sessionId 最早记录 ts；聚合同账户（recordAccount === activeAccount）且 ts >= 起点的全部记录 ----
+// ---- Issue #44 本会话聚合复刻：只沿 DSH 的 origin=subagent 父子关系归属 ----
 function normalizeSessionId(id) {
   if (!id) return '';
   return String(id).replace(/^session-/, '');
@@ -110,21 +109,44 @@ function recordAccount(r) {
   if (r.provider === 'openai') return 'openai';
   return null;
 }
-function currentSessionSummary(usageRecords, activeAccount, sessionId) {
+const sessionLineage = [
+  { sessionId: 'session-A' },
+  { sessionId: 'session-A-sub', parentSessionId: 'session-A', origin: 'subagent' },
+  { sessionId: 'session-B' },
+  { sessionId: 'session-C' },
+]
+function lineageIds(entries, sessionId) {
+  const root = normalizeSessionId(sessionId)
+  const owned = new Set([root])
+  const childrenByParent = new Map()
+  for (const entry of entries) {
+    if (!entry || entry.origin !== 'subagent') continue
+    const id = normalizeSessionId(entry.sessionId)
+    const parent = normalizeSessionId(entry.parentSessionId)
+    if (!id || !parent) continue
+    const children = childrenByParent.get(parent) || []
+    children.push(id)
+    childrenByParent.set(parent, children)
+  }
+  const pending = [root]
+  while (pending.length > 0) {
+    const parent = pending.shift()
+    for (const child of childrenByParent.get(parent) || []) {
+      if (owned.has(child)) continue
+      owned.add(child)
+      pending.push(child)
+    }
+  }
+  return owned
+}
+function currentSessionSummary(usageRecords, activeAccount, sessionId, entries) {
   if (!usageRecords || usageRecords.length === 0) return null;
   if (!sessionId) return null; // 无可用会话 ID：不猜测归属，显示 ¥0.000
-  const norm = normalizeSessionId(sessionId);
-  let sessionStart = null;
-  for (let i = 0; i < usageRecords.length; i++) {
-    const r = usageRecords[i];
-    if (normalizeSessionId(r.sessionId) !== norm) continue;
-    if (sessionStart === null || r.ts < sessionStart) sessionStart = r.ts;
-  }
-  if (sessionStart === null) return null;
+  const owned = entries ? lineageIds(entries, sessionId) : new Set([normalizeSessionId(sessionId)]);
   const acc = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0, costs: {} };
   for (let i = 0; i < usageRecords.length; i++) {
     const r = usageRecords[i];
-    if (r.ts < sessionStart) continue;
+    if (!owned.has(normalizeSessionId(r.sessionId))) continue;
     if (recordAccount(r) !== activeAccount) continue;
     acc.input += r.input;
     acc.cacheRead += r.cacheRead;
@@ -171,22 +193,19 @@ function totalSpend() {
 const sessions = sessionTotals();
 
 // ---- 断言 ----
-// 1) 本会话聚合（含子代理）：会话起点 = 当前 sessionId 最早记录 ts；聚合同账户 ts>=起点的全部记录
-const sA = currentSessionSummary(usageRecords, 'deepseek', 'session-A');
-const sB = currentSessionSummary(usageRecords, 'deepseek', 'session-B');
-const sC = currentSessionSummary(usageRecords, 'deepseek', 'session-C');
+// 1) 本会话聚合：主会话只包含自己和明确的子代理，不受同账户其他会话污染
+const sA = currentSessionSummary(usageRecords, 'deepseek', 'session-A', sessionLineage);
+const sB = currentSessionSummary(usageRecords, 'deepseek', 'session-B', sessionLineage);
+const sC = currentSessionSummary(usageRecords, 'deepseek', 'session-C', sessionLineage);
 const A2Tokens = 1000 + 500 + 0 + 2000 + 800 + 600 + 0 + 1500; // 会话 A 两条记录
 const subTokens = subRecord.input + subRecord.cacheRead + subRecord.cacheWrite + subRecord.output; // 子代理记录
 const B2Tokens = 2000 + 0 + 0 + 3000 + 500 + 100 + 0 + 1000; // 会话 B 两条记录
 const C1Tokens = 3000 + 0 + 0 + 5000; // 会话 C
 check('本会话 A tokens（A 2 次 + 同账户子代理 1 次）', sA.tokens, A2Tokens + subTokens);
-check('子代理记录被并入本会话 A（独立 sessionId、同账户、同时间窗）', sA.tokens > A2Tokens, true);
-check('本会话 B tokens（起点后同账户全部 = A + 子代理 + B）', sB.tokens, A2Tokens + subTokens + B2Tokens);
-check('本会话 C tokens（最旧起点 → 同账户全量）', sC.tokens, A2Tokens + subTokens + B2Tokens + C1Tokens);
-// A 与 B/C 花费不同（会话起点不同 → 聚合范围不同）
-check('A 花费 ≠ B 花费', sA.costs.CNY !== sB.costs.CNY, true);
-check('B 花费 ≠ C 花费', sB.costs.CNY !== sC.costs.CNY, true);
-check('会话聚合随起点单调：C >= B >= A（含子代理的会话窗重叠）', sC.costs.CNY >= sB.costs.CNY && sB.costs.CNY >= sA.costs.CNY, true);
+check('子代理记录被并入本会话 A（origin=subagent）', sA.tokens > A2Tokens, true);
+check('本会话 B 不再混入 A 或子代理', sB.tokens, B2Tokens);
+check('本会话 C 不再混入更早的其他会话', sC.tokens, C1Tokens);
+check('会话花费按谱系独立，不再随时间窗单调重叠', sA.costs.CNY !== sB.costs.CNY && sB.costs.CNY !== sC.costs.CNY, true);
 // 2) 今天/近一月/近30天/全部 与总账一致（会话聚合重叠不影响汇总口径）
 const totalOfAll = usageRecords.reduce(function (sum, r) { const c = costOf(r); return c != null ? sum + c : sum; }, 0);
 check('全部花费 = 全量记录直接求和（会话窗重叠不重复计费）', Math.round(totalSpend() * 1000) / 1000, Math.round(totalOfAll * 1000) / 1000);

--- a/tests/test-usage-compaction.mjs
+++ b/tests/test-usage-compaction.mjs
@@ -157,18 +157,36 @@ function refSpendSummary(records, nowMs, account, currency, balance) {
     offpeakDaysLeft: offpeakDailySpend > 0 ? Math.round(balance / offpeakDailySpend * 10) / 10 : null,
   }
 }
-function refCurrentSession(records, account, sessionId) {
-  if (!sessionId) return null
-  const norm = refNormalize(sessionId)
-  let start = null
-  for (const r of records) {
-    if (refNormalize(r.sessionId) !== norm) continue
-    if (start === null || r.ts < start) start = r.ts
+function refLineageIds(entries, sessionId) {
+  const root = refNormalize(sessionId)
+  const owned = new Set(root ? [root] : [])
+  const childrenByParent = new Map()
+  for (const entry of entries || []) {
+    if (!entry || entry.origin !== 'subagent') continue
+    const id = refNormalize(entry.sessionId || entry.id)
+    const parent = refNormalize(entry.parentSessionId || entry.parentId)
+    if (!id || !parent) continue
+    const children = childrenByParent.get(parent) || []
+    children.push(id)
+    childrenByParent.set(parent, children)
   }
-  if (start === null) return null
+  const pending = [root]
+  while (pending.length > 0) {
+    const parent = pending.shift()
+    for (const child of childrenByParent.get(parent) || []) {
+      if (owned.has(child)) continue
+      owned.add(child)
+      pending.push(child)
+    }
+  }
+  return owned
+}
+function refCurrentSession(records, account, sessionId, lineageEntries) {
+  if (!sessionId) return null
+  const owned = lineageEntries ? refLineageIds(lineageEntries, sessionId) : new Set([refNormalize(sessionId)])
   const acc = { input: 0, cacheRead: 0, cacheWrite: 0, output: 0, costs: {} }
   for (const r of records) {
-    if (r.ts < start) continue
+    if (!owned.has(refNormalize(r.sessionId))) continue
     if (refAccount(r) !== account) continue
     acc.input += r.input
     acc.cacheRead += r.cacheRead
@@ -193,10 +211,14 @@ function refSessionCount(records, account) {
 }
 
 // ---------- 桩环境（与 test-usage-ledger 同构；余额桩让 spendSummary 物化） ----------
-function makeStub() {
+function makeStub(sessionEntries) {
   const captured = { route: null, llmListener: null }
   const ctx = {
-    get(name) { return name === 'agentDefaultModel' ? { currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-chat' }) } : undefined },
+    get(name) {
+      if (name === 'agentDefaultModel') return { currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-chat' }) }
+      if (name === 'sessionController' && sessionEntries) return { list: async () => ({ items: sessionEntries }) }
+      return undefined
+    },
     credentials: { resolve: async (name) => (name === 'DEEPSEEK_API_KEY' ? { value: 'sk-test' } : null) },
     interval() { return () => {} },
     timeout() { return () => {} },
@@ -352,7 +374,11 @@ const fixture = buildBigFixture()
 writeFixture(dataDir1, fixture.snapshot, fixture.journalLines)
 const allRecords = fixture.snapshot.concat(fixture.journalLines.map((line) => JSON.parse(line)))
 
-const first = makeStub()
+const recentLineage = [
+  { sessionId: 'recent-check' },
+  { sessionId: 'recent-check-sub', parentSessionId: 'recent-check', origin: 'subagent' },
+]
+const first = makeStub(recentLineage)
 const dispose1 = m1.plugin.apply(first.ctx)
 await new Promise((resolve) => setTimeout(resolve, 50))
 const summary1 = await invokeSummary(first.captured.route, 'recent-check')
@@ -374,11 +400,10 @@ check('① 大账本折叠后 getUsageSummary 返回 200', !!summary1 && typeof 
     && sameMoney(summary1.spend.offpeakDailySpend, wantSpend.offpeakDailySpend)
     && sameMoney(summary1.spend.daysLeft, wantSpend.daysLeft),
     { got: summary1.spend, want: wantSpend })
-  const wantSession = refCurrentSession(allRecords, account, 'recent-check')
-  const wantSub = refCurrentSession(allRecords, account, 'recent-check-sub')
-  // v1.7 语义：主会话聚合 = 起点 + 同账户全部记录 → 本身已并入子代理记录（wantMain 含 sub），
-  // 故主会话与基线逐字段相等 + 子代理自身聚合也与基线相等，即为等价（且证明子代理未被丢账）
-  check('① currentSessionSummary 逐字段相等（主会话含同账户子代理并入）',
+  const wantSession = refCurrentSession(allRecords, account, 'recent-check', recentLineage)
+  const wantSub = refCurrentSession(allRecords, account, 'recent-check-sub', recentLineage)
+  // Issue #44 语义：主会话聚合 = 根会话 + origin=subagent 后代；同账户其他会话不再靠时间窗猜测并入。
+  check('① currentSessionSummary 逐字段相等（主会话只含明确子代理）',
     summary1.currentSession && summary1Sub.currentSession
     && summary1.currentSession.tokens === wantSession.tokens
     && close(summary1.currentSession.costs.CNY, wantSession.costs.CNY)
@@ -406,7 +431,7 @@ dispose1() // 冲刷：快照重写为窗内明细 + journal 滚动压缩 + summ
 }
 
 // 重启（重新 load）后总额不变（幂等）
-const second = makeStub()
+const second = makeStub(recentLineage)
 const dispose2 = m1.plugin.apply(second.ctx)
 await new Promise((resolve) => setTimeout(resolve, 50))
 const summary2 = await invokeSummary(second.captured.route, 'recent-check')
@@ -467,18 +492,26 @@ dispose2()
   legacy.push(makeRecord('mid-2', beijingTs(10, 9, 30), 'mid-session-sub', { cost: 0.125, input: 60, cacheRead: 0, cacheWrite: 0, output: 10 }))
   legacy.push(makeRecord('mid-3', NOW - 2 * 3600 * 1000, 'mid-session', { cost: 0.25, input: 100, cacheRead: 0, cacheWrite: 0, output: 20 }))
   writeFixture(dataDir2, legacy, [])
-  const stub2 = makeStub()
+  const legacyLineage = [
+    { sessionId: 'legacy-long' },
+    { sessionId: 'legacy-sub', parentSessionId: 'legacy-long', origin: 'subagent' },
+    { sessionId: 'legacy-other' },
+    { sessionId: 'mid-session' },
+    { sessionId: 'mid-session-sub', parentSessionId: 'mid-session', origin: 'subagent' },
+    { sessionId: 'mid-noise-sess' },
+  ]
+  const stub2 = makeStub(legacyLineage)
   const dispose2b = m2.plugin.apply(stub2.ctx)
   await new Promise((resolve) => setTimeout(resolve, 50))
   const legacyNow = await invokeSummary(stub2.captured.route, 'legacy-long')
-  const wantLegacy = refCurrentSession(legacy, 'deepseek', 'legacy-long')
-  check('② 会话起点早于压缩窗：currentSessionSummary 压缩前后 tokens 相等（含子代理与同日后续会话）',
+  const wantLegacy = refCurrentSession(legacy, 'deepseek', 'legacy-long', legacyLineage)
+  check('② 压缩窗外会话：currentSessionSummary 只含明确子代理，压缩前后 tokens 相等',
     legacyNow.currentSession && legacyNow.currentSession.tokens === wantLegacy.tokens, { got: legacyNow.currentSession, want: wantLegacy })
-  check('② 会话起点早于压缩窗：costs 压缩前后相等',
+  check('② 压缩窗外会话：明确子代理 costs 压缩前后相等',
     legacyNow.currentSession && close(legacyNow.currentSession.costs.CNY, wantLegacy.costs.CNY), { got: legacyNow.currentSession && legacyNow.currentSession.costs, want: wantLegacy.costs })
   const midNow = await invokeSummary(stub2.captured.route, 'mid-session')
-  const wantMid = refCurrentSession(legacy, 'deepseek', 'mid-session')
-  check('② 窗内会话保持起点当天逐条过滤：起点之前的同日噪声绝不混入',
+  const wantMid = refCurrentSession(legacy, 'deepseek', 'mid-session', legacyLineage)
+  check('② 窗内会话只含明确子代理：同日噪声和其他会话绝不混入',
     midNow.currentSession && midNow.currentSession.tokens === wantMid.tokens && close(midNow.currentSession.costs.CNY, wantMid.costs.CNY),
     { got: midNow.currentSession, want: wantMid })
   dispose2b()


### PR DESCRIPTION
## 这次修复解决什么
Closes #44。以前“本会话花费”用最早时间加同账户后续记录来猜子代理，所以并行会话会互相污染。

现在改为：
- 读取 DSH 的 sessionController 会话摘要；
- 只接受 `origin: subagent` 且 parentSessionId 指向当前会话的子孙节点；
- 从现有会话索引汇总主会话和全部后代，压缩前后口径一致；
- 老宿主没有 sessionController 时，只统计选中的会话，不再用时间窗口猜测。

## 验证
- 新增 Issue #44 专项父子/孙子会话、无标记 fork、循环谱系回归测试；
- 更新记账和压缩测试，锁定“并行同账户会话不混入”；
- `npx --yes node@20 tests/run-all.mjs` 全量通过；
- `git diff --check` 通过。

感谢 @xuezhaoyu 把污染场景和 DSH 的父子会话信号说明得很具体，这让修复可以从时间窗口猜测改成真正按谱系归属。