### PR TITLE
fix(ci): pin release tag discovery

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,7 +22,7 @@ jobs:
           else
             echo "RELEASE_PLEASE_TOKEN is configured; automatic release follow-up is enabled."
           fi
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           # A PAT lets the generated release commit/tag trigger downstream
           # workflows. The built-in token remains a safe manual-dispatch

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,11 @@
   "include-component-in-tag": false,
   "packages": {
     "plugin": {
+      "component": "dsh-bottom-info-bar",
       "package-name": "dsh-bottom-info-bar",
-      "changelog-path": "/CHANGELOG.md"
+      "changelog-path": "/CHANGELOG.md",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true
     }
   }
 }


### PR DESCRIPTION
修复 Release Please 在现有 v1.10.18 tag 上无法识别历史、错误扫描出 2.0.0 的问题。

- 明确 plugin 组件名
- 在包级别固定无组件 v* tag 规则
- 升级到 googleapis/release-please-action@v5

已补齐并发布 v1.10.18，后续应自动递增到 v1.10.19。