### PR TITLE
ci: hold release pull requests for confirmation

### DIFF
--- a/.github/workflows/auto-merge-own.yml
+++ b/.github/workflows/auto-merge-own.yml
@@ -3,6 +3,12 @@ name: Auto-merge own PRs
 # 目標：只有倉庫擁有者 songoao25 的 PR 自動開啟 auto-merge（CI 通過後自動 squash），
 # 其他人（外部貢獻者 / fork）的 PR 保持手動，需人工 Review + 手動合併。
 # 這符合業界「trust-by-author」慣例：可信作者的 PR 自動化，不可信作者保留人工閘門。
+#
+# 例外（2026-09-11 新增）：Release Please 開的「發布 PR」不自動合併。
+# 原因：Release Please 用 owner 的 RELEASE_PLEASE_TOKEN 開 PR，作者看起來就是 owner，
+# 因此發布 PR 會被當成「自己的 PR」放行 —— 等於把唯一該有人把關的環節也自動化了。
+# 2026-09-11 的 v2.0.0 誤發事故正是如此（詳見 MEMORY.md）。
+# 發布 PR 的分支名固定為 release-please--*，且會被加上 autorelease: 標籤，兩者都排除。
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
@@ -13,8 +19,12 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    # 只有 owner 的 PR 才進入；draft PR 不自動合
-    if: github.event.pull_request.user.login == github.repository_owner && github.event.pull_request.draft == false
+    # 只有 owner 的 PR 才進入；draft PR 不自動合；發布 PR 留給人工/AI 確認後再合併
+    if: >-
+      github.event.pull_request.user.login == github.repository_owner
+      && github.event.pull_request.draft == false
+      && !startsWith(github.event.pull_request.head.ref, 'release-please--')
+      && !contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease')
     runs-on: ubuntu-latest
     steps:
       - name: Report automation token mode

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,18 @@
   - `plugin/scripts/` — 构建脚本
 - `install.sh` / `uninstall.sh` — 一键安装/卸载（默认装到 web profile，可用 --profile 覆盖）
 - `tests/` — 静态/烟雾测试与多个单测（dual-mode、display-name、density-toggle、spend-accounting、static-client）
-- `docs/` — INSTALL、DUAL-MODE-DESIGN、OPENCODE-GO-SUPPORT-EVAL
+- `docs/` — 设计、审计、QA、运维与调研文档（INSTALL、TECH-DESIGN、PRD、RELEASE、PRICING-SOURCES 等）
 - `.github/` — CI、CodeQL、Dependabot、Issue/PR 模板
+
+## 发布机制（2026-09-11 定型，Agent 必读）
+
+本仓库的版本号 **全部由 Release Please 自动管理**，Agent 与人都不要插手：
+
+1. PR 合并进 main 后，`.github/workflows/release-please.yml` 会自动算出下一个版本号、写好 `CHANGELOG.md`，并开一个「发布 PR」。
+2. 发布 PR 带 `autorelease: pending` 标签、分支名为 `release-please--*`，被 `auto-merge-own.yml` **排除**，不会自动合并 —— **这是唯一的发布闸门**。
+3. 合并该发布 PR 后：自动打 tag → `publish-npm.yml` 自动发布到 npm。
+
+**严禁手工修改** `plugin/package.json` 的 `version`、`.release-please-manifest.json`、`CHANGELOG.md` 顶部版本号。手工 bump 会让 Release Please 找不到「上次发布」的基准，从而把全部历史当成未发布内容、算出错误的大版本 —— 2026-09-11 的 v2.0.0 误发事故就是这么来的（详见 `MEMORY.md`）。
 
 ## 关键约定
 
@@ -41,4 +51,4 @@
 - 跑测试：见 `tests/run-all.mjs`
 - CI 检查项：`.github/workflows/ci.yml`
 
-- 版本发布铁律（2026-09-04 用户明确要求）：每一次小 bug 修复、小更新都必须走一个版本发布（bump patch + CHANGELOG + tag + npm），严禁“修了不发”；已实现的版本更新提醒功能依赖此纪律，否则浪费
+- 版本发布铁律（2026-09-04 用户明确要求，2026-09-11 更新机制）：每一次小 bug 修复、小更新都必须走一个版本发布，严禁“修了不发”；已实现的版本更新提醒功能依赖此纪律，否则浪费。**具体执行方式见上方「发布机制」——版本号 / CHANGELOG / tag 全部由 Release Please 自动完成，Agent 只需保证提交信息规范（fix/feat），并在发布 PR 出现时提醒用户确认合并。**

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -61,6 +61,30 @@
 - 最终状态（已核实）：npm `latest` = 1.10.19；GitHub「Latest」= v1.10.19（与 npm 一致）；main 的 package/manifest/CHANGELOG 均为 1.10.19；无遗留 tag / 开放 PR。**打上 `last-release-sha` 后 release-please 再跑（main 15:43:20）产出为空 —— 确认基线钉死生效，不会再自动冒出 2.0.0。**
 - 教训：本仓库的「手工 bump + PR + 打 tag」SOP 与「release-please 自动发布」是两套并存的机制，**会互相打架**。手工 bump 到 X 之后，release-please 仍会基于坏基线再算一次并自动合并发布。以后发布前应先确认 release-please 的基线配置，或干脆在发布窗口临时禁用 `release-please.yml` / `auto-merge-own.yml`。
 
+### 2.0.0 事故的完整追因（2026-09-11 补，用户追问「为什么偏偏今天」）
+
+- **真正的导火索：用户今天 05:58 手动加上了 `RELEASE_PLEASE_TOKEN` 密钥。** 此前 release-please 只能拿 `GITHUB_TOKEN`（GitHub 刻意限制：用它做的事**不会触发后续 workflow**），所以机器人即使算出发布 PR，也不会自动合并、不会自动打 tag —— 整条链子**一直没通电**。换成 owner 本人的 PAT 后，机器人开的 PR 作者显示为 `songoao25`，恰好命中 `auto-merge-own.yml` 的「owner 自己的 PR 自动合并」→ 开 PR 23 秒后就被合掉 → 自动打 tag → 全链一次性跑通。**不是代码变了，是这把钥匙把自动链子接通了。**
+- **release-please 日志给出的铁证（run 34617031262）**：`⚠ Expected 1 releases, only found 0` → `❯ looking for tagName: v1.10.19` → `✔ Collecting commits since all latest releases` → `❯ Set(0) {}`（**基准集合为空 = 无下界，回溯全部历史**）→ 翻到 v1.3.0 的 BREAKING CHANGE「移除『信息概览』页面」→ `✔ updating from 1.10.19 to 2.0.0`。修好后再跑（run 34618033624）显示 `Set(1) { '661dbad…' }` → `✔ Using configured lastReleaseSha` → `✔ No user facing commits found`，确认钉子生效。
+- **时间差是结构性的、赢不了的**：机器人从「PR 合并」到「动手」只要 ~3 秒，而人工打 tag 至少要几分钟。所以只要还手工改版本号，这个竞态必然复现 —— 这正是必须改成「机器人独占版本号」的原因。
+- **残留物（用户指出「catalog changelog 里没删掉」，用户记得没错）**：只删 tag + 回退文件**不够**，release-please 的**工作分支** `release-please--branches--main--components--dsh-bottom-info-bar` 仍留在远端，其 `plugin/package.json` 还是 `2.0.0`、CHANGELOG 里还躺着那段「信息概览」BREAKING CHANGE。**已删除该分支**，并逐个体检 50 个分支确认**无任何分支再残留 2.0.0**。
+- **唯一剩下的痕迹**：`ee9c4bf chore(main): release 2.0.0 (#69)` 这条提交仍在 main 历史里。清除它需要改写已发布历史 + 强推受保护的 main，属工业界禁忌且会打乱所有克隆；评估为**无害**（类型是 chore，release-please 已不会读它；`MEMORY.md` 已完整记录来龙去脉，后续 Agent 读到只会明白因果，不会重蹈）。故**决定不改写历史**。
+
+### 发布机制定型：Release Please 独占版本号 + 发布闸门（2026-09-11 用户拍板）
+
+- 背景两问的通俗答案：**Release Please 是专职「发版」的自动化工具**（盯 main → 按提交信息算版本号 → 写 CHANGELOG → 开发布 PR → 打 tag）；**重复操作在于「谁定版本号」有两个人在做**（人的手工 bump vs 机器人自动算）。方案定为「**机器人独占 + 一道人工闸门**」，兼顾自动化与工业标准。
+- 落地改动（本 PR）：
+  1. `.github/workflows/auto-merge-own.yml` 的 `if` 增加两条排除：`!startsWith(head.ref, 'release-please--')` 与 `!contains(join(labels.*.name, ','), 'autorelease')`。**必须用分支名判断**——实测日志显示 release-please 是「先开 PR、后加标签」，只靠标签在 `opened` 事件上会漏判。保留标签判断用于后续 `synchronize` 事件兜底。
+  2. `AGENTS.md` 新增「发布机制（Agent 必读）」章节，并把末尾「版本发布铁律」改为指向该机制：**严禁手工改 `plugin/package.json` 的 version / `.release-please-manifest.json` / CHANGELOG 顶部**；Agent 只负责写规范提交、并在发布 PR 出现时提醒用户确认合并。
+- 新流程：写 `fix:`/`feat:` 提交 → PR（自己的 PR 仍全自动合并）→ 机器人开「发布 PR」→ **闸门拦住，等人/AI 确认** → 合并后自动打 tag → `publish-npm.yml` 自动发 npm。
+
+### 分支清理：只保留 main（2026-09-11 用户指令）
+
+- 用户判断：正常流程下分支合并完就该删，理论上只该剩主线。判断正确，但**必须先确认内容都已合并**，否则删掉会丢工作。
+- 关键方法坑：本仓库用 **squash 合并**，`git branch --merged` **完全失效**（分支提交不在 main 历史里，即使内容已合并也显示「未合并」）。**必须改问 GitHub 的 PR 记录**（`gh pr list --state all`）才知道真相。
+- 执行结果：远端 50 个分支 → 逐个体检：48 个有已合并 PR、`pr-41`/`pr-42` 对应 PR #41/#42 已合并、`codex/refactor-settings-billing-actions` 内容已被 main 完全覆盖 → **删除 49 个，只剩 `main`**；本地分支与陈旧 remote-tracking 引用同步清空（`git update-ref -d` 强制清理，`git remote prune` 未生效）。
+- 清理中确认可安全丢弃的旧内容：`.workbuddy/memory/2026-09-04.md`（已迁入本文件）、v1.4.0 时代的旧版 `docs/*`（已被 main 现有 29 份新文档取代）、`promo/*`（早前 `chore: remove private development materials` 已刻意移除）、`plugin/src/client-settings.js`（设置页已重写）。
+- **防止复发**：已开启仓库设置 `delete_branch_on_merge=true`，今后 PR 合并不再堆积分支。同时顺手修正 `AGENTS.md` 中已过时的 `docs/` 说明（原写的 DUAL-MODE-DESIGN / OPENCODE-GO-SUPPORT-EVAL 早已不在 main）。
+
 ---
 
 ## 2026-09-04


### PR DESCRIPTION
Implements the release mechanism we settled on: **Release Please owns version
numbers; the release PR is the one gate that stays manual.**

## Why the gate matters

`auto-merge-own.yml` trusts PRs authored by the repository owner. Release
Please opens its release PR with the owner's `RELEASE_PLEASE_TOKEN`, so that PR
*is* authored by the owner — the one PR that most needs a look was the one PR
that skipped the gate. That is how 2.0.0 got tagged on 2026-09-11.

The rule now skips release PRs:

```yaml
&& !startsWith(github.event.pull_request.head.ref, 'release-please--')
&& !contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease')
```

The **branch check has to come first**. The run log from the 2.0.0 incident
shows release-please opening the PR and only afterwards adding its label
(`Successfully opened pull request: 69` → `Successfully added labels
autorelease: pending`), so a label-only test would still miss the `opened`
event. The label check stays as a backstop for later `synchronize` events.

## Resulting flow

| Step | Who |
|---|---|
| Write a `fix:` / `feat:` commit, open a PR | Agent |
| CI + auto-merge | Automatic |
| Release Please computes the version, writes the CHANGELOG, opens a release PR | Automatic |
| **Merge the release PR** | **Confirmation gate** |
| Tag → publish to npm | Automatic |

## Also

- `AGENTS.md`: new 「发布机制」 section. Version numbers, the manifest and the
  CHANGELOG top entry are **off limits for hand edits** — a manual bump is what
  robbed Release Please of its baseline in the first place. The old
  「版本发布铁律」 now points at this mechanism instead of describing a manual
  bump.
- `MEMORY.md`: records the full investigation — the token insight, the
  `Set(0) {}` proof from the run log, and the stale release-please branch.
- Fixed the stale `docs/` description in `AGENTS.md` (it still named two files
  that no longer exist on main).

## Verification

All four workflow files parse as valid YAML; the full test suite is green.
