### PR TITLE
test: enforce the hard-won rules with automated guards

### DIFF
--- a/.github/workflows/auto-merge-own.yml
+++ b/.github/workflows/auto-merge-own.yml
@@ -19,12 +19,16 @@ permissions:
 
 jobs:
   enable-auto-merge:
-    # 只有 owner 的 PR 才進入；draft PR 不自動合；發布 PR 留給人工/AI 確認後再合併
+    # 只有 owner 的 PR 才進入；draft PR 不自動合；發布 PR 留給人工/AI 確認後再合併。
+    # 三道判別條件是有意的縱深防禦（任一命中即攔下）：分支名最穩、標籤次之、標題最後。
+    # 這三道都偏向「多攔」，代價只是某個普通 PR 沒自動合併（看得見、可手動合），
+    # 而漏放的代價是發布 PR 被靜默合併（v2.0.0 事故）。方向必須偏安全。
     if: >-
       github.event.pull_request.user.login == github.repository_owner
       && github.event.pull_request.draft == false
       && !startsWith(github.event.pull_request.head.ref, 'release-please--')
       && !contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease')
+      && !startsWith(github.event.pull_request.title, 'chore(main): release ')
     runs-on: ubuntu-latest
     steps:
       - name: Report automation token mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,11 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth: 0 —— tests/test-source-guards.mjs 的「守卫 4」需要与基线的完整
+      # diff 才能判断本 PR 有没有手工改版本元数据；浅克隆会让它取不到基线而跳过。
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
           node-version: 20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,14 @@
 
 **严禁手工修改** `plugin/package.json` 的 `version`、`.release-please-manifest.json`、`CHANGELOG.md` 顶部版本号。手工 bump 会让 Release Please 找不到「上次发布」的基准，从而把全部历史当成未发布内容、算出错误的大版本 —— 2026-09-11 的 v2.0.0 误发事故就是这么来的（详见 `MEMORY.md`）。
 
+## 自动化守卫（CI 会拦住，不存在「绕过」）
+
+`tests/test-source-guards.mjs` 把几条血的教训从「文档约定」升级为「CI 硬约束」。违反即 CI 红、合不进去：
+
+1. **禁止裸读宿主服务属性**（`ctx.某个服务名`）。cordis 4 的 Context 是 Proxy，读取未在 `inject` 里声明的服务属性会抛 `cannot get property "X" without inject` —— **即使该服务确实存在也一样抛**。本仓库因此踩坑三次（v1.10.1 `ctx.settings`、2026-09-04 同类、Issue #67 `ctx.sessionController` 导致 500）。合法写法只有三种：① 加进本文件 `inject: [...]`；② 改用 `ctx.get('name')`；③ 老宿主兜底时写成同一行的 `try { ... } catch { ... }`。
+2. **项目记忆只允许 `MEMORY.md` 一个**。一旦出现 `.workbuddy/`、`.cursor/memory/` 之类工具专属目录即失败——记忆属于项目，不属于工具。
+3. **普通 PR 不得手工修改版本元数据**（`plugin/package.json` 的 `version`、`.release-please-manifest.json`、`CHANGELOG.md`）；只有 `release-please--*` 的发布 PR 有权修改。确需抢修时，在提交信息里写 `[release-metadata-override]` 并在 PR 描述里说明原因（因为 main 开了 `enforce_admins`，没有逃生舱会被永久卡死）。
+
 ## 关键约定
 
 - 修改 `plugin/` 后需重启 `dsh web`（插件在宿主启动时组合，刷新页面不够）

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -95,6 +95,36 @@
   3. 一旦发现被回滚且**无未提交改动**，`git reset --hard origin/main` 即可完全复原（本次即如此修复）。
 - 与既有教训同源：「checkout 停在旧分支 = 用不上主线新版的第一大原因」（2026-09-04 已记录）。本次是该坑的**加强版** —— 停的甚至就是 `main` 本身，光看分支名根本发现不了。
 
+### 独立审计结论（2026-09-11 末，用户要求「彻底修复，防止永远出现问题」）
+
+**源码级定论（下载 release-please@17.11.2 逐行核对，此前只有推断）：**
+- `last-release-sha` **只用于终止提交遍历**（`manifest.js:287` 无条件 `break`），CHANGELOG 的切分用的是「找到的发布 SHA」（`manifest.js:319` 传 `releaseShasByPath[path]`，不是配置值）。→ **该钉子永久安全，绝不会造成版本条目重复。**
+- **2.0.0 的精确机制**：`needsBootstrap = releasesFound < expectedReleases`（`manifest.js:253`）。当时「找不到 1.10.19 的 GitHub Release」且标签也还没推 → `releasesFound=0 < 1` → `needsBootstrap=true` → 因 `bootstrapSha` 未设，`commit.sha === bootstrapSha` 永不命中、`!needsBootstrap` 分支也进不去 → **遍历无限回溯**至 `commitSearchDepth`(500) 上限 → 翻出远古 BREAKING CHANGE → 判为 major。→ 钉死 `last-release-sha` 正好补上这个洞（它不受 `needsBootstrap` 影响）。
+
+**发布闸门已实测（不再是推断）：** 建了一个名为 `release-please--gate-verification` 的测试分支 + **空提交**（万一误合也零副作用）→ `auto-merge-own` 工作流结果为 **`skipped`**、`autoMergeRequest` 为空；对照组普通分支为 `success`。**闸门确实拦得住**，测试 PR #75 已关闭、分支已删。另确认**不会死锁**：main 的必需检查是 "CI"，而 `ci.yml` 对**所有 PR** 都跑（发布 PR #69 当时 CI 为 success），所以被拦下的发布 PR 始终可合。
+
+**npm 发布包反向验证：** 下载 `dsh-bottom-info-bar@1.10.19` 逐个核对：`ctx.inject(['sessionController'])` 在、裸访问仅剩注释、调用点双保险在、500 日志在、版本号 1.10.19。**用户拿到的是真修复。**
+
+**审计中发现并已修的问题：**
+- `docs/RELEASE.md` 仍在教「手工改版本号 + 手工打 tag」——正是闯祸流程，且读起来像操作手册，Agent 可能照做。已加历史存档标注并指向新机制（PR #74）。
+- 本地 `main` 陈旧导致工作区被回滚（见上一节）。
+- 本机 DSH 宿主进程（20:53 启动）早于修复构建（00:02），**仍跑旧代码**；需重启 `dsh web`（见「待用户执行」）。
+
+**新增自动化守卫（PR #76）：`tests/test-source-guards.mjs`** —— 把「只能靠自觉」的约定升级为 CI 硬约束，违反即合不进去：
+1. **禁止裸读宿主服务属性**：扫描全部 `plugin/src/*.js`，`ctx.X` 若既不在本文件 `inject` 声明里、又不在同一行/前 3 行的 `try` 保护内，即失败。**这条挡的是整类 bug**（本仓库已踩三次：v1.10.1 `ctx.settings`、2026-09-04 同类、Issue #67 `ctx.sessionController`）。
+2. **记忆唯一性**：出现 `.workbuddy/`、`.cursor/memory/` 等工具专属目录即失败。
+3. **`MEMORY.md` 必须存在，且 `AGENTS.md` 必须指向它并写明禁令**。
+4. **普通 PR 不得手工改版本元数据**（`package.json` version / `.release-please-manifest.json` / `CHANGELOG.md`），只有 `release-please--*` 分支可改；**逃生舱**：提交信息含 `[release-metadata-override]`（因为 main 开了 `enforce_admins`，没有逃生舱会被永久卡死）。
+- 守卫全部做过**反向验证**（注入违规必须 FAIL，恢复后必须 PASS），不是"写完就算"。
+- `ci.yml` 的 checkout 加了 `fetch-depth: 0`：守卫 4 需要与基线的完整 diff，浅克隆会让它取不到基线。
+
+**发布闸门加固为三层**（`auto-merge-own.yml`）：分支名 `release-please--*`（最稳，PR 创建时即有）→ 标签 `autorelease`（release-please 是「先开 PR 后加标签」，故不能只靠它）→ 标题 `chore(main): release `。三层都是 `&&` 否定，偏向「多拦」；漏放代价是发布 PR 被静默合并，多拦代价只是某个普通 PR 需手动合——**方向必须偏安全**。
+
+**无法修 / 需要用户执行的（如实记录，不假装已解决）：**
+- `ee9c4bf chore(main): release 2.0.0 (#69)` 仍在 main 历史里。main 分支保护 `allow_force_pushes: false` + `enforce_admins: true`，**改写历史在规则层面就不可能**。评估为无害：类型是 chore（release-please 不读它算版本），且本节已完整记录因果。
+- 报告者环境是 Windows + cordis 4.0.1，本仓库的复现与验证都在 macOS + cordis 4.0.2 完成——跨平台差异未覆盖。
+- 本机需重启 `dsh web` 才能跑上修复后的代码（Agent 不能自己重启：会中断正在进行的会话）。
+
 ---
 
 ## 2026-09-04

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -22,6 +22,7 @@ console.log('build OK → lib/')
 
 const cases = [
   ['test-release-version（package/manifest/changelog 一致性）', ['tests/test-release-version.mjs'], join(root), process.execPath],
+  ['test-source-guards（源码守卫：裸服务访问 / 记忆文件唯一性 / 发布元数据不可手工改）', ['tests/test-source-guards.mjs'], join(root), process.execPath],
   ['smoke-static-host', ['tests/smoke-static-host.mjs'], join(root), process.execPath],
   ['test-alpha4-client-contract（alpha.4 client manifest/slots/React）', ['tests/test-alpha4-client-contract.mjs'], join(root), process.execPath],
   ['test-static-client（plugin/src/client-bundle.js）', ['tests/test-static-client.js'], join(root), process.execPath],

--- a/tests/test-source-guards.mjs
+++ b/tests/test-source-guards.mjs
@@ -1,0 +1,169 @@
+// 源码守卫（Source guards）：把几条"血的教训"从文档约定变成 CI 能拦住的硬约束。
+//
+// 背景：本仓库同一个坑踩了三次 ——
+//   v1.10.1  ctx.settings        裸访问 → 插件树加载失败，宿主起不来
+//   2026-09-04 同类问题再次出现
+//   Issue #67  ctx.sessionController 裸访问 → getUsageSummary 恒返 500
+// 每次都只写进记忆，结果每次都复发。文档挡不住，只有自动化能挡住。
+import { readFileSync, existsSync, readdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+let failures = 0
+function check(name, condition, detail) {
+  if (condition) console.log('PASS  ' + name)
+  else { failures += 1; console.log('FAIL  ' + name + (detail !== undefined ? '\n      ' + detail : '')) }
+}
+
+// ---------- 守卫 1：禁止裸读宿主服务属性 ----------
+//
+// cordis 4 的 Context 是 Proxy：读取未在 `inject` 声明的服务属性会抛
+// `cannot get property "X" without inject`，**即使该服务确实存在也一样抛**。
+// 合法写法只有两种：
+//   a) 该服务已在本文件 `inject: [...]` 里声明；
+//   b) 用 try/catch 包住（仅用于「老宿主/非 cordis 宿主」的兜底形态）。
+// 其余一律视为 bug 苗子。
+const FRAMEWORK_MEMBERS = new Set([
+  // cordis Context / 服务的公开成员，不是「按名字取服务」，不会触发 without inject
+  'get', 'inject', 'on', 'once', 'off', 'emit', 'effect', 'logger', 'provide',
+  'plugin', 'timeout', 'interval', 'setTimeout', 'setInterval', 'registry',
+  'reflect', 'fiber', 'scope', 'waterfall', 'parallel', 'bail', 'serial',
+  'start', 'stop', 'isolate', 'root', 'extend', 'config', 'name', 'dispose',
+])
+
+function stripComments(source) {
+  // 保留换行与长度，让行号保持准确
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, p1) => p1 + ' '.repeat(m.length - p1.length))
+}
+
+function injectListOf(source) {
+  const m = source.match(/\binject\s*:\s*\[([^\]]*)\]/)
+  if (!m) return new Set()
+  return new Set([...m[1].matchAll(/['"]([^'"]+)['"]/g)].map((x) => x[1]))
+}
+
+const SOURCE_FILES = [
+  'plugin/src/host.js',
+  'plugin/src/client-bundle.js',
+  'plugin/src/host-locale.js',
+  'plugin/src/constants.js',
+  'plugin/src/locales.js',
+]
+
+const offenders = []
+for (const rel of SOURCE_FILES) {
+  const abs = join(root, rel)
+  if (!existsSync(abs)) continue
+  const raw = readFileSync(abs, 'utf8')
+  const injected = injectListOf(raw)
+  const lines = stripComments(raw).split('\n')
+  lines.forEach((line, index) => {
+    for (const match of line.matchAll(/\bctx\.([A-Za-z_$][\w$]*)/g)) {
+      const prop = match[1]
+      if (FRAMEWORK_MEMBERS.has(prop)) continue
+      // a) 已在 inject 声明 → 合法
+      if (injected.has(prop)) continue
+      // b) 同一行或前 3 行内有 try（= 兜底形态，例如 host-locale.js 与 client-bundle.js 的写法）
+      const window = lines.slice(Math.max(0, index - 3), index + 1).join('\n')
+      if (/\btry\b/.test(window)) continue
+      offenders.push(`${rel}:${index + 1}  ctx.${prop}\n        ${line.trim()}`)
+    }
+  })
+}
+
+check(
+  '守卫 1：不存在未声明 inject、又未用 try/catch 保护的裸服务访问',
+  offenders.length === 0,
+  offenders.length === 0 ? undefined
+    : offenders.join('\n      ') +
+      '\n\n      修法：① 把该服务加进本文件的 `inject: [...]`；② 或改用 ctx.get(\'name\')；' +
+      '\n      ③ 或（仅老宿主兜底）写成同一行的 try { ... } catch { ... }。详见 MEMORY.md / Issue #67。'
+)
+
+// ---------- 守卫 2：记忆文件必须唯一且通用 ----------
+//
+// 项目记忆属于项目，不属于工具。任何工具专属的隐藏记忆目录都不允许出现。
+const FORBIDDEN_MEMORY_PATHS = [
+  '.workbuddy', '.cursor/memory', '.aider', '.continue/memory', '.codeium',
+  '.claude/memory', '.gemini/memory', '.codex/memory', '.specstory',
+]
+const foundForbidden = FORBIDDEN_MEMORY_PATHS.filter((p) => existsSync(join(root, p)))
+
+check(
+  '守卫 2：不存在工具专属的记忆目录（记忆必须只放 MEMORY.md）',
+  foundForbidden.length === 0,
+  foundForbidden.length === 0 ? undefined
+    : '发现：' + foundForbidden.join(', ') +
+      '\n      修法：把内容迁入根目录 MEMORY.md 后删除该目录。规则见 MEMORY.md 顶部「使用规则」。'
+)
+
+// ---------- 守卫 3：通用记忆文件必须存在，且被 AGENTS.md 指向 ----------
+const memoryPath = join(root, 'MEMORY.md')
+const hasMemory = existsSync(memoryPath)
+check('守卫 3a：根目录存在唯一的通用记忆文件 MEMORY.md', hasMemory)
+
+if (hasMemory) {
+  const agents = readFileSync(join(root, 'AGENTS.md'), 'utf8')
+  check(
+    '守卫 3b：AGENTS.md 明确指向 MEMORY.md（保证任何 Agent 都能找到记忆）',
+    /MEMORY\.md/.test(agents) && /严禁任何 Agent 自建/.test(agents),
+    'AGENTS.md 缺少「项目记忆」段或未声明「禁止自建记忆」规则'
+  )
+  const memory = readFileSync(memoryPath, 'utf8')
+  check(
+    '守卫 3c：MEMORY.md 自身写明「禁止自建工具专属记忆」的规则',
+    /严禁任何 Agent 自建/.test(memory),
+    'MEMORY.md 顶部「使用规则」缺少该条'
+  )
+}
+
+// ---------- 守卫 4：发布元数据不允许被手工修改（仅 PR 场景）----------
+//
+// 手工 bump 版本号会让 Release Please 找不到「上次发布」的基准，从而把全部历史
+// 当成未发布内容、算出错误的大版本 —— 2026-09-11 的 v2.0.0 事故即由此而来。
+// 该守卫需要 CI 提供的 git 上下文，本地跑（无 GITHUB_BASE_REF）时自动跳过。
+const baseRef = process.env.GITHUB_BASE_REF || ''
+const headRef = process.env.GITHUB_HEAD_REF || ''
+if (!baseRef) {
+  console.log('SKIP  守卫 4：非 PR 场景（无 GITHUB_BASE_REF），跳过发布元数据检查')
+} else if (headRef.startsWith('release-please--')) {
+  console.log('PASS  守卫 4：Release Please 的发布 PR 有权修改版本元数据')
+} else {
+  const { execFileSync } = await import('node:child_process')
+  const git = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim()
+  let changed = null
+  try {
+    git(['fetch', '--no-tags', '--quiet', 'origin', baseRef])
+    changed = git(['diff', '--name-only', `origin/${baseRef}...HEAD`]).split('\n').filter(Boolean)
+  } catch (err) {
+    console.log('WARN  守卫 4：无法取得基线（' + String(err && err.message).split('\n')[0] + '），跳过本次检查')
+  }
+  if (changed) {
+    const GUARDED = ['.release-please-manifest.json', 'plugin/package.json', 'CHANGELOG.md']
+    const touched = changed.filter((f) => GUARDED.includes(f))
+    // 逃生舱：万一 Release Please 自身把元数据弄坏了，必须还有办法人工抢修。
+    // 因为 main 开了 enforce_admins，没有这个标记就会被永久卡死。
+    // 用法：在 PR 的任一提交信息里写上 [release-metadata-override]，并在 PR 描述里说明原因。
+    let override = false
+    try {
+      const log = git(['log', `origin/${baseRef}..HEAD`, '--format=%B'])
+      override = log.includes('[release-metadata-override]')
+    } catch (err) { /* 取不到提交信息就当作没有授权，宁可拦住 */ }
+    check(
+      '守卫 4：普通 PR 不得手工修改版本元数据（版本号由 Release Please 独占）',
+      touched.length === 0 || override,
+      touched.length === 0 ? undefined
+        : '被修改：' + touched.join(', ') +
+          (override ? '\n      （已检测到 [release-metadata-override]，本次放行）' : '') +
+          '\n      版本号 / CHANGELOG / manifest 由 Release Please 自动维护，手工改会破坏它的基准，' +
+          '\n      进而重演 v2.0.0 误发事故。发版请合并 Release Please 开出的「发布 PR」。详见 AGENTS.md「发布机制」。' +
+          '\n      确有抢修需要时：在提交信息里加 [release-metadata-override] 并在 PR 描述里说明原因。'
+    )
+  }
+}
+
+console.log(failures === 0 ? '\n结果：全部 PASS' : '\n结果：' + failures + ' 项 FAIL')
+process.exit(failures === 0 ? 0 : 1)


### PR DESCRIPTION
## Why

Every rule this repo learned the hard way has lived only in prose — and the
record shows prose does not hold:

| Lesson | Written down after | Recurred |
|---|---|---|
| bare `ctx.<service>` read throws on cordis 4 | v1.10.1 (`ctx.settings`) | 2026-09-04, then issue #67 (`ctx.sessionController`, permanent 500) |
| version numbers belong to Release Please | #64 / #66 | 2026-09-11 unattended 2.0.0 release |
| memory belongs to the project | — | `.workbuddy/memory/` written again this week |

`tests/test-source-guards.mjs` converts them into CI failures.

## The guards

**1. No bare host-service property reads.**
Scans every `plugin/src/*.js`. A `ctx.X` fails unless `X` is declared in that
file's `inject: [...]` or a `try` appears on the same line / the three
preceding lines. This covers **the whole class**, not the single instance that
bit us. `ctx.credentials`, `ctx.locale` and `ctx.slots` pass legitimately; the
two non-cordis fallbacks (`ctx.settings`, `ctx.modelDirectories`) pass because
they are inline-guarded.

**2. Project memory stays in `MEMORY.md` alone.**
A tool-specific directory (`.workbuddy/`, `.cursor/memory/`, …) fails the build.
Memory belongs to the project, not to a tool.

**3. `MEMORY.md` must exist, and `AGENTS.md` must point at it** and state the
ban — so the next agent finds it without having to guess.

**4. Ordinary PRs may not edit release metadata.**
`plugin/package.json`'s version field, `.release-please-manifest.json` and
`CHANGELOG.md` are off limits; only `release-please--*` branches may touch them.

There is a deliberate **escape hatch**: `[release-metadata-override]` in a
commit message. `main` has `enforce_admins: true`, so without one, a genuinely
corrupted manifest could never be repaired — a guard that can brick the repo is
not a guard.

## Verified in both directions

A guard that cannot fail is worthless, so each was tested by injecting a
violation and confirming a red result:

```
FAIL  守卫 1: plugin/src/host.js:1146  ctx.someUndeclaredService
FAIL  守卫 2: 发现：.workbuddy
FAIL  守卫 4: 被修改：plugin/package.json
PASS  守卫 4: Release Please 的发布 PR 有权修改版本元数据
```

Restoring the files returns everything to PASS.

## Release gate: three discriminators

The gate now checks **branch name**, **`autorelease` label**, and **title**.
All three conditions are negated (`&& !…`), so each added check biases toward
holding a PR back. Over-holding costs someone one manual merge; under-holding
costs a silently merged release PR — the 2.0.0 failure. The bias must point at
safety.

The branch check remains the load-bearing one: release-please opens the PR and
only then adds its label, so a label-only test misses the `opened` event.

## Two supporting changes

- `ci.yml` checks out with `fetch-depth: 0`. Guard 4 needs the diff against its
  base; a shallow clone would make it skip silently — a guard that quietly
  no-ops is worse than none.
- `MEMORY.md` records the source-level findings from the audit, including the
  two things that cannot be fixed and are now stated plainly instead of being
  quietly dropped.
