### PR TITLE
test: pin the contract between the two release stages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,11 +26,40 @@
 
 ## 发布机制（2026-09-11 定型，Agent 必读）
 
-本仓库的版本号 **全部由 Release Please 自动管理**，Agent 与人都不要插手：
+本仓库的版本号 **全部由 Release Please 自动管理**，Agent 与人都不要插手。
 
-1. PR 合并进 main 后，`.github/workflows/release-please.yml` 会自动算出下一个版本号、写好 `CHANGELOG.md`，并开一个「发布 PR」。
-2. 发布 PR 带 `autorelease: pending` 标签、分支名为 `release-please--*`，被 `auto-merge-own.yml` **排除**，不会自动合并 —— **这是唯一的发布闸门**。
-3. 合并该发布 PR 后：自动打 tag → `publish-npm.yml` 自动发布到 npm。
+发版是**一条两段式流水线**（不是两套并行机制 —— 两段做的事完全不重叠）：
+
+```
+写 fix:/feat: 提交 → PR → CI → 自动合并进 main
+                                    │
+        ┌───────────────────────────┘
+        ▼
+  【第 1 段】release-please.yml（合并到 main 时触发）
+      算版本号 → 写 CHANGELOG → 开「发布 PR」
+                                    │
+        ┌───────────────────────────┘
+        ▼
+  【人工闸门】auto-merge-own.yml 把发布 PR 排除在自动合并之外
+      → 由人（或提示 Agent）确认后手动合并 ← 全链唯一的人工环节
+                                    │
+        ┌───────────────────────────┘
+        ▼
+  【第 2 段】release-please 打标签 v1.2.3 → publish-npm.yml（标签触发）
+      校验「标签版本 == plugin/package.json 版本」→ npm publish
+```
+
+**两段之间靠一个隐式契约衔接，改任何一环都会断链，而且可能静默失败：**
+
+| 契约 | 由谁决定 | 改错的后果 |
+|---|---|---|
+| 标签必须带 `v` 前缀 | `release-please-config.json` 的 `include-v-in-tag: true` | 标签变成 `1.2.3`，`publish-npm` 的 `v*.*.*` **永远匹配不上** → GitHub 有发布页但 npm 永远没有新版，**且无任何报错** |
+| 标签不含组件名前缀 | `include-component-in-tag: false` | 标签变成 `dsh-bottom-info-bar-v1.2.3`，同样静默失配 |
+| 包路径 `plugin` | `release-please-config.json` 与 `.release-please-manifest.json` 的键 | 版本号写不回 `package.json` |
+| `package-name` | 必须等于 `plugin/package.json` 的 `name` | Release Please 拒绝发布 |
+| `changelog-path` | 指向仓库根 `CHANGELOG.md` | 更新日志写错文件 |
+
+**以上契约全部由 `tests/test-release-chain.mjs` 自动校验**（14 条断言）。改动发布相关的任何文件后跑一次全量测试即可确认链条完好。
 
 **严禁手工修改** `plugin/package.json` 的 `version`、`.release-please-manifest.json`、`CHANGELOG.md` 顶部版本号。手工 bump 会让 Release Please 找不到「上次发布」的基准，从而把全部历史当成未发布内容、算出错误的大版本 —— 2026-09-11 的 v2.0.0 误发事故就是这么来的（详见 `MEMORY.md`）。
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -120,6 +120,27 @@
 
 **发布闸门加固为三层**（`auto-merge-own.yml`）：分支名 `release-please--*`（最稳，PR 创建时即有）→ 标签 `autorelease`（release-please 是「先开 PR 后加标签」，故不能只靠它）→ 标题 `chore(main): release `。三层都是 `&&` 否定，偏向「多拦」；漏放代价是发布 PR 被静默合并，多拦代价只是某个普通 PR 需手动合——**方向必须偏安全**。
 
+### ⚠ 自我纠正：「两套发布机制」的说法不准确（2026-09-11 用户追问）
+
+- 我先前对用户说「仓库里仍并存两套发布自动化，只改一个链条就会断」，**这个框架有误导性**，让用户以为它们是重复、冲突的两套东西。**事实并非如此。**
+- **准确的关系：发版是一条两段式流水线，两段做的事完全不重叠。**
+  - 第 1 段 `release-please.yml`（合并到 main 时触发）：算版本号 → 写 CHANGELOG → 开「发布 PR」→ 合并后**打标签**。
+  - 第 2 段 `publish-npm.yml`（标签触发）：校验「标签版本 == package.json 版本」→ **发布到 npm**。
+- **真正打架的从来不是这两个文件**，而是「手工改版本号」vs「Release Please 改版本号」—— 两个主体争夺同一个决定权。该冲突已通过「版本号收归 Release Please 独占」解决。把这条讲清楚很重要，否则会误导后续 Agent 去做一次不必要的「合并两套机制」重构。
+- **不应也不需要合并成一份**：① 两段之间正好夹着唯一的人工确认（合并发布 PR），合并等于拆掉闸门；② 合并就得自行重写 Release Please 的版本计算逻辑，代码更多、更易坏；③ 标签是两段之间干净的标准接口。
+- **但用户担心的风险真实存在，只是位置不同**：真正的脆弱点是两段之间的**隐式契约**（尤其是「标签必须带 v 前缀」与「publish-npm 的 `v*.*.*` 触发器」必须一致）。改坏它会**静默失效** —— GitHub 上有标签有发布页，npm 上永远没有新版本，**全程零报错**。这是整条链上最危险的失效模式。
+
+### 发布链条契约测试（2026-09-11）
+
+- 新增 `tests/test-release-chain.mjs`，把上述隐式契约变成 14 条 CI 断言，覆盖：
+  1. **标签格式两侧一致**（`include-v-in-tag: true` ↔ `v*.*.*` ↔ `${GITHUB_REF_NAME#v}` 剥离）—— 最关键，失效时静默；
+  2. 路径与包名对齐（包路径 `plugin` 与 manifest 键一致、`package-name` == package.json 的 name、`changelog-path` 指向根 CHANGELOG、标签不含组件前缀）；
+  3. 两段触发器齐备（release-please 监听 main、publish-npm 保留 `workflow_dispatch` 手动兜底、NPM_TOKEN 接线）；
+  4. **人工闸门仍在**（分支名 + 标签两条判别都在）；
+  5. **`last-release-sha` 钉子仍在**。
+- **反向验证过**：把 `include-v-in-tag` 改成 `false` → 契约 1a FAIL；删掉闸门的分支名判别 → 契约 4a FAIL；恢复后全 PASS。
+- 这一条补上了我先前说「架构固有复杂度」时**其实可以消除的那部分**：复杂度不是靠合并消除，而是靠**把暗契约写成明契约 + 自动校验**来消除。
+
 **无法修 / 需要用户执行的（如实记录，不假装已解决）：**
 - `ee9c4bf chore(main): release 2.0.0 (#69)` 仍在 main 历史里。main 分支保护 `allow_force_pushes: false` + `enforce_admins: true`，**改写历史在规则层面就不可能**。评估为无害：类型是 chore（release-please 不读它算版本），且本节已完整记录因果。
 - 报告者环境是 Windows + cordis 4.0.1，本仓库的复现与验证都在 macOS + cordis 4.0.2 完成——跨平台差异未覆盖。

--- a/tests/run-all.mjs
+++ b/tests/run-all.mjs
@@ -22,6 +22,7 @@ console.log('build OK → lib/')
 
 const cases = [
   ['test-release-version（package/manifest/changelog 一致性）', ['tests/test-release-version.mjs'], join(root), process.execPath],
+  ['test-release-chain（发布链条契约：标签格式/路径/闸门/钉子必须两边一致）', ['tests/test-release-chain.mjs'], join(root), process.execPath],
   ['test-source-guards（源码守卫：裸服务访问 / 记忆文件唯一性 / 发布元数据不可手工改）', ['tests/test-source-guards.mjs'], join(root), process.execPath],
   ['smoke-static-host', ['tests/smoke-static-host.mjs'], join(root), process.execPath],
   ['test-alpha4-client-contract（alpha.4 client manifest/slots/React）', ['tests/test-alpha4-client-contract.mjs'], join(root), process.execPath],

--- a/tests/test-release-chain.mjs
+++ b/tests/test-release-chain.mjs
@@ -1,0 +1,132 @@
+// 发布链条契约（Release chain contract）
+//
+// 发版是一条两段式流水线：
+//   第 1 段 Release Please：算版本号 → 写 CHANGELOG → 打标签
+//   第 2 段 publish-npm   ：标签 → 校验 → 发布到 npm
+//
+// 两段之间靠一个**隐式契约**衔接，而这个契约过去没有任何地方写下来、也没有任何检查：
+//   标签格式（v 前缀）必须同时被两边认同。
+//
+// 一旦有人只改一边（例如把 include-v-in-tag 改成 false），标签会变成 `1.10.20`，
+// publish-npm 的 `v*.*.*` 触发器永远匹配不上 → **发版静默失败**：GitHub 上有标签有发布页，
+// npm 上却永远没有新版本，而且全程没有任何报错。这是整条链上最危险的失效模式。
+//
+// 本测试把契约变成断言：改坏任何一环，CI 立刻红。
+import { readFileSync, existsSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)))
+const read = (rel) => readFileSync(join(root, rel), 'utf8')
+const readJson = (rel) => JSON.parse(read(rel))
+
+let failures = 0
+function check(name, condition, detail) {
+  if (condition) console.log('PASS  ' + name)
+  else { failures += 1; console.log('FAIL  ' + name + (detail !== undefined ? '\n      ' + detail : '')) }
+}
+
+const config = readJson('release-please-config.json')
+const manifest = readJson('.release-please-manifest.json')
+const publishNpm = read('.github/workflows/publish-npm.yml')
+const releasePlease = read('.github/workflows/release-please.yml')
+
+// ---------- 契约 1：标签格式必须两边一致（最关键，失效时静默）----------
+//
+// Release Please 侧：include-v-in-tag 决定标签是 `v1.2.3` 还是 `1.2.3`。
+// publish-npm 侧：`on.push.tags` 的 glob 决定它认哪种标签。
+// 两者必须同时为「带 v」或同时为「不带 v」。
+const packageKeys = Object.keys(config.packages || {})
+const perPackage = config.packages?.[packageKeys[0]] || {}
+// 包级设置覆盖顶层设置（release-please 的语义）
+const includeVInTag = perPackage['include-v-in-tag'] ?? config['include-v-in-tag'] ?? true
+const publishTriggersOnV = /tags:\s*\n\s*-\s*['"]v\*\.\*\.\*['"]/.test(publishNpm)
+const publishTriggersOnBare = /tags:\s*\n\s*-\s*['"][0-9*][^'"]*['"]/.test(publishNpm)
+
+check(
+  '契约 1a：Release Please 会打出带 v 前缀的标签（include-v-in-tag: true）',
+  includeVInTag === true,
+  'include-v-in-tag 为 ' + JSON.stringify(includeVInTag) + '，标签将不带 v 前缀'
+)
+check(
+  '契约 1b：publish-npm 的标签触发器与之一致（v*.*.*）',
+  publishTriggersOnV && !publishTriggersOnBare,
+  '若两侧不一致，发版会静默失败：GitHub 有标签，npm 永远没有新版本，且无任何报错'
+)
+check(
+  '契约 1c：publish-npm 在比较版本号时剥掉 v 前缀（${GITHUB_REF_NAME#v}）',
+  publishNpm.includes('${GITHUB_REF_NAME#v}'),
+  '否则 tag 1.2.3 与 package.json 的 1.2.3 会被判为不一致而拒绝发布'
+)
+
+// ---------- 契约 2：路径与包名必须对齐 ----------
+const pluginPkg = readJson('plugin/package.json')
+
+check(
+  '契约 2a：release-please 只有一个包路径，且该路径下确实有 package.json',
+  packageKeys.length === 1 && existsSync(join(root, packageKeys[0], 'package.json')),
+  '配置里的包路径：' + JSON.stringify(packageKeys)
+)
+check(
+  '契约 2b：manifest 的键与配置的包路径完全一致（否则版本号不会写回 package.json）',
+  JSON.stringify(Object.keys(manifest)) === JSON.stringify(packageKeys),
+  'manifest: ' + JSON.stringify(Object.keys(manifest)) + ' vs 配置: ' + JSON.stringify(packageKeys)
+)
+check(
+  '契约 2c：package-name 与 plugin/package.json 的 name 一致（否则 Release Please 拒绝发布）',
+  perPackage['package-name'] === pluginPkg.name,
+  '配置: ' + perPackage['package-name'] + ' vs package.json: ' + pluginPkg.name
+)
+check(
+  '契约 2d：changelog-path 指向仓库根目录的 CHANGELOG.md',
+  String(perPackage['changelog-path'] || '').replace(/^\//, '') === 'CHANGELOG.md',
+  'changelog-path: ' + perPackage['changelog-path']
+)
+check(
+  '契约 2e：标签里不含组件名前缀（include-component-in-tag: false）',
+  config['include-component-in-tag'] === false && perPackage['include-component-in-tag'] === false,
+  '否则标签会变成 dsh-bottom-info-bar-v1.2.3，publish-npm 的 v*.*.* 匹配不上'
+)
+
+// ---------- 契约 3：两段流水线的触发器都要在 ----------
+check(
+  '契约 3a：release-please 监听 push 到 main（否则合并后不会自动发版）',
+  /branches:\s*\n?\s*-?\s*\[?main\]?/.test(releasePlease) && /release-please-action@/.test(releasePlease),
+  'release-please.yml 缺少 push→main 触发或缺少 action 调用'
+)
+check(
+  '契约 3b：publish-npm 保留 workflow_dispatch 手动兜底（自动链断了还能人工发版）',
+  /workflow_dispatch:/.test(publishNpm),
+  '去掉手动入口后，一旦自动链出问题就只能改代码才能发版'
+)
+check(
+  '契约 3c：publish-npm 用 NPM_TOKEN 发布（唯一密钥入口）',
+  /NODE_AUTH_TOKEN:\s*\$\{\{\s*secrets\.NPM_TOKEN\s*\}\}/.test(publishNpm),
+  'publish-npm.yml 未把 NPM_TOKEN 接到 NODE_AUTH_TOKEN'
+)
+
+// ---------- 契约 4：人工闸门必须仍然存在 ----------
+//
+// 这条闸门在 auto-merge-own.yml 里，不在本流水线文件中，所以特别容易被误删。
+const autoMerge = read('.github/workflows/auto-merge-own.yml')
+check(
+  '契约 4a：发布 PR 仍被排除在自动合并之外（分支名判别）',
+  autoMerge.includes("!startsWith(github.event.pull_request.head.ref, 'release-please--')"),
+  '闸门被移除后，发布 PR 会被静默自动合并 —— 即 v2.0.0 事故的直接成因'
+)
+check(
+  '契约 4b：发布 PR 仍被排除在自动合并之外（autorelease 标签判别，兜底）',
+  autoMerge.includes("!contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease')"),
+  '标签判别是 release-please 改动分支命名时的兜底'
+)
+
+// ---------- 契约 5：基准钉子必须还在 ----------
+check(
+  '契约 5：last-release-sha 仍然钉死（防止提交遍历无限回溯到远古历史）',
+  /^[0-9a-f]{40}$/.test(String(config['last-release-sha'] || '')),
+  '钉子被移除后，一旦 Release Please 找不到「上次发布」，就会把全部历史当成未发布内容 —— ' +
+  '正是 v2.0.0 被判为 major 的成因'
+)
+
+console.log(failures === 0 ? '\n结果：全部 PASS' : '\n结果：' + failures + ' 项 FAIL')
+process.exit(failures === 0 ? 0 : 1)


### PR DESCRIPTION
Follow-up to a good question: can the two release workflows be merged into one?

**No — and they are not two competing mechanisms.** They are two stages of one pipeline that do not overlap:

| Stage | Trigger | Job |
|---|---|---|
| release-please | merge to main | decide the version, write the CHANGELOG, open the release PR, then tag |
| publish-npm | tag push | verify tag == package.json version, publish to npm |

The only thing that ever fought was *manual version bumping vs release-please*, over who decides the version. That is already resolved.

Merging them would be worse: the human approval step sits **between** the two stages, so collapsing them either deletes the gate or forces us to reimplement release-please's version logic.

## The real fragility, now pinned

The stages share an implicit contract that was written down nowhere and checked nowhere. Its load-bearing clause is the tag format:

```
release-please writes v-prefixed tags  ← include-v-in-tag: true
publish-npm listens for v*.*.*         ← .github/workflows/publish-npm.yml
```

Fliping that one setting makes the chain **fail silently**: GitHub shows a tag and a release page, npm never receives the version, and nothing reports an error.

`tests/test-release-chain.mjs` turns the contract into 14 assertions covering the tag format, path and identity alignment, both stages' wiring, the human gate, and the pinned baseline.

## Verified by breaking it

```
include-v-in-tag: false        → FAIL 契约 1a
remove branch discriminator    → FAIL 契约 4a
restore                        → all PASS
```

`AGENTS.md` now carries the pipeline diagram plus a table of every clause and what breaks if it is changed — the coupling is visible to whoever edits one of these files instead of living in someone's head.