### PR TITLE
docs: restructure both READMEs and fix the stale update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,182 +7,206 @@
 [![Last commit](https://img.shields.io/github/last-commit/songoao25/dsh-bottom-info-bar)](https://github.com/songoao25/dsh-bottom-info-bar)
 [![CI](https://img.shields.io/github/actions/workflow/status/songoao25/dsh-bottom-info-bar/ci.yml)](https://github.com/songoao25/dsh-bottom-info-bar/actions)
 
-The **best-adapted bottom info bar for [DeepSeek Harness](https://github.com/deepseek-ai)**, and a drop-in replacement for the native stats row under the composer. It shows a **fresh balance**, **subscription quota**, or **provider billing data** at a glance, alongside provider & model, peak/off-peak pricing, and real spend — **smart and concise**, **conflict-free**, and **native in look and feel**: it auto-detects the billing mode, replaces the native row instead of duplicating it, and matches the model switcher exactly. Install once; it activates automatically on every launch.
+A drop-in replacement for the stats row under the DeepSeek Harness composer.
 
-## Preview
+It keeps everything that row already showed — turns and steps, LLM time, tool calls, cache hit rate, input/output tokens — and adds what you actually want to see while you work: **your real balance** (or subscription quota, or this month's bill), the **provider and exact model**, **peak/off-peak pricing** with a countdown to the next switch, and **what this conversation has cost so far**.
 
-![Bottom Info Bar preview: ChatGPT subscription, DeepSeek API, and OpenCode Go subscription](/assets/bottom-info-bar-preview.jpeg)
+Install once, restart once, then it activates on every launch. The billing mode is detected automatically, and **estimated data is never displayed**.
 
-The preview was captured before the English UI update. From top to bottom, the combined screenshot shows **ChatGPT subscription**, **DeepSeek API**, and **OpenCode Go subscription**. Each account is shown in **full view** followed by **compact view**.
+![Bottom Info Bar preview: ChatGPT subscription, DeepSeek balance, and OpenCode Go subscription — each in full and compact view](assets/bottom-info-bar-preview.jpeg)
 
-## Features
+<sub>The screenshot uses the Chinese UI; with DSH's language set to English the labels switch automatically. From top to bottom: **ChatGPT subscription**, **DeepSeek balance**, **OpenCode Go subscription** — each shown in **full** view followed by **compact** view.</sub>
 
-- **Three-state billing bar** — Auto-detects whether the active provider is **subscription-based** (quota windows: Codex / OpenCode Go / Zhipu / Xiaomi MiMo Token Plan), **cloud-billing-based** (this month's real bill: Together / Fireworks / AWS Bedrock / Cloudflare), or **balance-based**. The three modes replace each other, never overlap; balance mode stays exactly as before.
-- **ChatGPT subscription card (pure local)** — When the active provider is **ChatGPT / Codex**, the bar decodes `~/.codex/auth.json` locally and shows the **real plan tier + expiry date**, e.g. `ChatGPT · Plus | Expires 2026-09-16` — zero network, real fields straight from OpenAI's own login token (chatgpt_plan_type / subscription_active_until), no local estimation. Not signed in → **Refresh failed**, with a reauthorization reminder in the tooltip. Binding, token refresh and the `openai-codex` model route are **not part of this plugin** — install the companion plugin [**dsh-chatgpt-subscription**](https://github.com/songoao25) (separate repo) to bind your ChatGPT account; this bar only reads the token.
-- **Subscription quota display (OpenCode Go / Zhipu / Xiaomi MiMo Token Plan)** — When the active provider is a subscription service, the bar shows the **subscription service · model** (e.g. `OpenCode Go · V4 Flash`, `Xiaomi MiMo · Mimo-V2.5`), the **5-hour / weekly / monthly quota remaining** per window (remaining = 100 − used), and a **countdown to the next reset** (e.g. `Resets in 1d 21h`). **Quota and countdown always match** — both come from the same window. Quota sources:
-  - **OpenCode Go** — reads quota from `opencode.ai/zen/go/v1/usage` via `OPENCODE_GO_API_KEY` (Settings → Models) or the opencode CLI login (`~/.local/share/opencode/auth.json`); missing key → "not configured" hint instead of an error.
-  - **Zhipu (zai / zai-coding-cn)** — reads GLM Coding Plan quota via `ZAI_CODING_CN_API_KEY` (fallback: `ZAI_API_KEY`); shows plan tier + 5-hour window remaining.
-  - **Xiaomi MiMo Token Plan** — reads monthly Credits quota via `XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY` per region (fallback: `XIAOMI_API_KEY`); shows plan name + monthly window.
-- **Cloud-billing display (real monthly bill)** — When the active provider is **Together / Fireworks / AWS Bedrock / Cloudflare**, the bar reads the official billing API and shows **this month's real spend**, e.g. `Together | This month $12.34`, `AWS Bedrock | This month $45.60 · Budget 46%`. Cloudflare additionally shows daily free-quota remaining and a UTC-midnight reset countdown **only when the API actually reports a free allowance** (otherwise it shows real usage only — never fabricated). All bill figures come from official provider APIs; **no local estimation is ever displayed**. Missing keys → "not configured" hint.
-- **Drop-in replacement** — Replaces the native stats row while keeping its core original information (turns/steps, LLM latency, tool calls, cache hit rate, in/out tokens) with a native-consistent layout. Speed metrics (TTFT, tok/s) move to the hover tooltip so the row stays on a single line.
-- **Provider & model detection** — Follows the active session in DSH and reads provider/model names from DSH's current model list (for example, `DeepSeek · V41-Flash`). Newly published models are picked up automatically, without a plugin model list to maintain. While the current model is not available yet, the bar says it is reading the model instead of guessing or borrowing another model's data.
-- **Fresh balance** — Fetches real balance from DeepSeek's `/user/balance` API, refetches immediately when the bar opens/refreshes or the provider changes, then auto-refreshes every 60 s. This is polling rather than a provider-pushed real-time stream; provider-side billing delay still applies. The last known snapshot is kept on failure so usage is never interrupted.
-- **Peak / off-peak pricing** — Shows peak (alert red, bold) and off-peak (green, bold) prices with a countdown to the next switch; hidden automatically for providers without tiered pricing. The text labels remain visible in both appearances.
-- **Real spend tracking** — Records every `llm/stream` request (usage × unit price) and aggregates precisely by **this session (includes subagents) / today / last 30 days / all time**. Subagents share the same provider account, so their records are folded into the current session's spend (session starts at the earliest record of the current session, then every same-account record from that moment on counts). Records are persisted to disk — nothing is lost on restart.
-- **Bold numbers** — Balance, countdown, spend, and all stats are rendered with bold numerals for instant readability.
-- **Full / compact toggle** — Click the bar to switch between two strict modes (debounced).
-- **Low-balance alert** — When the balance drops below ¥20, its amount and adjacent `Low` status turn alert red.
-- **Real data only** — The bar only ever shows balances / quotas / plans / bills returned by each provider's official API; local spend estimation is never displayed.
-- **Info Bar settings** — Choose what appears, search the list, and set colors with native controls. The list scrolls inside its card so the page stays stable; changes save automatically. Restore the default display or colors, export billing as CSV/JSON, or confirm to clear billing records saved by this plugin.
-- **Stays fast over months (v1.9)** — Ledger details auto-archive into summaries and stats are computed incrementally, so bar refreshes never slow down with usage; ledger file permissions are hardened automatically on startup.
+## At a glance
 
-## Supported Providers (v1.7)
+- **Three billing modes, auto-detected** — balance, subscription quota, or cloud bill. They replace each other and never overlap.
+- **Real data only** — every balance, quota, plan and bill comes from the provider's official API. Nothing is estimated locally.
+- **Exactly what DSH shows** — the provider and model match DSH's model switcher, and newly published models are picked up automatically.
+- **Peak / off-peak pricing** — both prices plus a countdown to the next switch (weekends count as off-peak all day).
+- **Honest spend tracking** — this conversation (including subagents), today, last 30 days, and all time — persisted to disk, nothing lost on restart.
+- **Native by design** — it replaces the native row instead of duplicating it; click to switch full/compact, and choose which fields and colors appear.
 
-The bar follows the active session in DSH and detects the provider from its current model list — **zero configuration needed**. Set up your API key in DeepSeek Harness (Settings → Models), and the bar recognizes the active provider automatically. If DSH has not supplied the model yet, the bar waits instead of guessing.
-
-### Balance-based providers
-| Provider | Display Name | Credential Key | Balance API |
-|---|---|---|---|
-| deepseek / deepseek-official | DeepSeek | DEEPSEEK_API_KEY | Official API |
-| openai | OpenAI | OPENAI_API_KEY | Estimated (no public API) |
-| moonshotai / moonshotai-cn / kimi-coding | Kimi | MOONSHOT_API_KEY (fallback: KIMI_API_KEY) | Official API |
-| openrouter | OpenRouter | OPENROUTER_API_KEY | Official API |
-| stepfun | StepFun | STEPFUN_API_KEY | Official API |
-| xiaomi | Xiaomi MiMo | XIAOMI_API_KEY | Official API |
-
-### Subscription-based providers (quota windows)
-| Provider | Display Name | Token Source |
-|---|---|---|
-| codex / chatgpt / openai-codex | ChatGPT / Codex | `~/.codex/auth.json` (read-only; local JWT decode → plan + expiry) |
-| opencode-go / opencode | OpenCode Go | OPENCODE_GO_API_KEY or opencode auth.json |
-| zai / zai-coding-cn | Zhipu | ZAI_CODING_CN_API_KEY (fallback: ZAI_API_KEY) |
-| xiaomi-token-plan-cn / -sgp / -ams | Xiaomi MiMo | XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY (fallback: XIAOMI_API_KEY) |
-
-### Cloud-billing providers (real monthly bill)
-| Provider | Display Name | Credential Key | Billing API |
-|---|---|---|---|
-| together | Together | TOGETHER_API_KEY | Official Usage API (month spend) |
-| fireworks | Fireworks | FIREWORKS_API_KEY | Official Billing API (period spend) |
-| amazon-bedrock | AWS Bedrock | AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY | AWS Cost Explorer + Budgets (month spend + budget %) |
-| cloudflare-ai-gateway / cloudflare-workers-ai | Cloudflare | CLOUDFLARE_API_KEY + CLOUDFLARE_ACCOUNT_ID (Token needs Billing read) | Billable Usage API (Alpha, real usage) |
-
-**Unsupported providers**: If your provider is not in the list above, the bar shows a **Not supported** hint instead of displaying another provider's data.
-
-## UI language
-
-The plugin follows **Settings → General → Language** in DSH. Choose Chinese to keep the original Chinese UI or English for the labels shown in this README. Switching languages updates the UI without reloading; there is no separate plugin language selector. Chinese documentation remains available.
-
-Host messages use DSH’s saved language preference. A remote browser’s unsaved language choice cannot change host-only text. External provider/system messages keep their original wording. See [localization notes](docs/LOCALIZATION.md) for scope and verification.
-
-## Requirements
-
-- [DeepSeek Harness](https://github.com/deepseek-ai) (`dsh` CLI) installed and used via the web interface (`dsh web`)
-- [pnpm](https://pnpm.io/) (used by `dsh plugin`)
-
-## Installation
-
-### Option 1 — One-command script (recommended)
-
-```bash
-git clone https://github.com/songoao25/dsh-bottom-info-bar.git
-cd dsh-bottom-info-bar
-./install.sh                # installs to the "web" profile; use --profile <name> to override
-```
-
-### Option 2 — NPM package (recommended for future updates)
+## Quick start
 
 ```bash
 dsh plugin --profile web add dsh-bottom-info-bar
 ```
 
-To update later:
+Then **restart `dsh web`** — plugins are composed when the host process starts, so a page refresh is not enough.
 
-```bash
-dsh plugin --profile web update dsh-bottom-info-bar --latest
-```
+Set your provider's API key under **Settings → Models** in DSH. Nothing else to configure.
 
-### Option 3 — dsh plugin command from a local checkout
+<details>
+<summary>Other ways to install (and which one to pick)</summary>
+
+**Recommended: the npm command above.** It is the only install method that lets the built-in update reminder hand you a working update command — see [Updating](#updating).
+
+**From a local checkout** (for development, or to run unreleased code):
 
 ```bash
 git clone https://github.com/songoao25/dsh-bottom-info-bar.git
 dsh plugin --profile web add /path/to/dsh-bottom-info-bar/plugin
 ```
 
-> **Restart `dsh web` after installing or updating.** Plugins are composed when the host process starts; a page refresh alone is not enough.
+This creates a `link:` install. It tracks your checkout rather than npm, so updates are `git pull` instead of a package install — see [Updating](#updating).
 
-For detailed installation, troubleshooting, and upgrade instructions, see [docs/INSTALL.md](docs/INSTALL.md).
+**One-command script** — clone and install in one step:
 
-## Usage
+```bash
+git clone https://github.com/songoao25/dsh-bottom-info-bar.git
+cd dsh-bottom-info-bar
+./install.sh                # installs into the "web" profile; --profile <name> to override
+```
 
-- **Hover** the bar for details: balance, per-token pricing, next price-switch time, and this-conversation spend (today / last 30 days / all time).
-- **Click** the bar to toggle between full and compact modes.
-- **Version reminder**: once per full DSH startup, the plugin checks NPM; if a newer version exists, it shows a red **Update available** label with the new version in its tooltip. The label only reminds you and never updates code automatically; tell an Agent with local terminal access to help update it.
+Like the local-checkout option, this produces a `link:` install.
 
-## Configuration
+Detailed instructions and troubleshooting: [docs/INSTALL.md](docs/INSTALL.md).
+</details>
 
-- **API key**: configure the DeepSeek API key under **Settings → Models** (environment variable `DEEPSEEK_API_KEY`). Without it, the plugin shows a hint and every other feature keeps working.
-- **Data scope**: in Beijing time, peak hours are 09:00–12:00 and 14:00–18:00 on weekdays; Saturday and Sunday use off-peak prices all day. Built-in pricing covers DeepSeek V4 models plus OpenAI reference prices; models not in the table are excluded from spend statistics.
-- **Mode**: the bar automatically chooses balance, subscription-quota, or billing display from the active session's provider. No manual mode selection is needed.
-- **Subscription sources**:
-  - **ChatGPT (Codex)**: install the companion plugin [**dsh-chatgpt-subscription**](https://github.com/songoao25) (separate repo) and bind your ChatGPT account once — it maintains the token in `~/.codex/auth.json` (mode `0600`) and registers the ChatGPT models. This bar only **reads** the local token to show the plan and expiry fields it contains; it never refreshes, writes back, or injects credentials. Missing credentials show **Not connected**, with instructions to install **dsh-chatgpt-subscription** and sign in. Missing plan fields remain blank rather than being guessed.
-  - **OpenCode Go**: set `OPENCODE_GO_API_KEY` under **Settings → Models**, or log in with the opencode CLI (writes the `opencode-go` entry in `~/.local/share/opencode/auth.json`). Without a key the bar shows a "not configured" hint instead of an error.
+## Billing modes
 
-#### ChatGPT subscription: known limitations
+The bar follows the active session in DSH and picks the display from the provider — no manual mode selection.
 
-- This plugin reads only the local token fields supplied by the companion plugin. If the token does not contain a plan or expiry, the bar leaves that detail unset rather than inventing it.
-- Available models depend on your subscription plan; model access is provided by the companion plugin **dsh-chatgpt-subscription**.
+### Balance mode (DeepSeek, Kimi, OpenRouter, StepFun, Xiaomi MiMo, OpenAI reference)
 
-### Data storage (plugin-owned directory)
+Shows the **real balance** from the provider's `/user/balance` (or equivalent) API. It refetches the moment the bar opens, refreshes, or the provider changes, then polls every 60 seconds. The last known snapshot is kept on failure so the row never goes blank.
 
-All spend data lives in the plugin's own data directory, isolated from other plugins and DSH configuration:
+When the balance drops below ¥20, the amount and a `Low` label turn red.
+
+### Subscription mode (ChatGPT / Codex, OpenCode Go, Zhipu, Xiaomi MiMo Token Plan)
+
+Shows **quota remaining per window** (5-hour / weekly / monthly, where remaining = 100 − used) and a **countdown to the next reset**. Quota and countdown always come from the same window, so they can never disagree.
+
+- **ChatGPT / Codex** — decoded **locally** from `~/.codex/auth.json`, showing the real plan tier and expiry date (for example `ChatGPT · Plus | Expires 2026-09-16`). Zero network calls: the values come straight from OpenAI's own login token, never estimated. Not signed in → **Refresh failed** with a reauthorization hint. Binding, token refresh and the `openai-codex` model route belong to the companion plugin [dsh-chatgpt-subscription](https://github.com/songoao25) — this bar only reads the token, and never writes it back.
+- **OpenCode Go** — reads quota from `opencode.ai/zen/go/v1/usage` using `OPENCODE_GO_API_KEY` (Settings → Models) or the opencode CLI login at `~/.local/share/opencode/auth.json`. Missing key → a "not configured" hint, not an error.
+- **Zhipu** — GLM Coding Plan quota via `ZAI_CODING_CN_API_KEY` (fallback `ZAI_API_KEY`): plan tier plus the 5-hour window.
+- **Xiaomi MiMo Token Plan** — monthly Credits quota via `XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY` per region (fallback `XIAOMI_API_KEY`): plan name plus the monthly window.
+
+In compact mode the bar prefers the shortest window (5-hour > weekly > monthly), because it refreshes fastest; if the 5-hour window is unavailable it falls back to weekly, then monthly.
+
+### Billing mode (Together, Fireworks, AWS Bedrock, Cloudflare)
+
+Shows **this month's real spend** from the provider's official billing API, for example `Together | This month $12.34` or `AWS Bedrock | This month $45.60 · Budget 46%`. Cloudflare also shows daily free-quota remaining and a UTC-midnight reset countdown — but **only when the API actually reports a free allowance**; otherwise it shows real usage alone rather than inventing a quota. Missing keys → a "not configured" hint.
+
+## Spend tracking
+
+Every `llm/stream` request is recorded (usage × unit price) and aggregated four ways: **this conversation** (including subagents), **today**, **last 30 days**, and **all time**.
+
+Subagents bill to the same provider account, so their records are folded into the current session. The billed price is fixed the moment a response completes, so later price-table updates never rewrite history. Models with no known price keep their token counts but are excluded from money totals, and are never given an invented cost.
+
+Nothing is lost on restart: the journal is synchronously confirmed before the UI counts a new charge, and if that write fails the bar says **Spend not saved** instead of quietly dropping the amount. Ledger details auto-archive into summaries and stats are computed incrementally, so refreshing stays fast even after months of use.
+
+## Updating
+
+Once per full DSH startup the plugin checks npm for a newer version. If one exists, a red **Update available** label appears.
+
+**Click the label** and the update command is copied to your clipboard — paste it into a terminal, run it, then restart `dsh web`. The label briefly confirms with "Update command copied".
+
+Hovering the label explains both paths: ask an agent that has terminal access, or click to copy the command yourself.
+
+The copied command matches how the plugin was installed:
+
+| Installed via | Command you get |
+|---|---|
+| npm (`dsh plugin add dsh-bottom-info-bar`) | `dsh plugin --profile <profile> add dsh-bottom-info-bar@latest` |
+| `link:` — local checkout or the one-command script | `git -C <your checkout> pull --ff-only` |
+
+It is never applied automatically. The plugin only tells you a newer version exists; nothing on your machine changes until you run the command yourself.
+
+## Supported providers
+
+The bar detects the provider from DSH's current model list — **no configuration needed**. Set the key up in DSH (Settings → Models) and the bar recognises it. If DSH has not supplied a model yet, the bar waits rather than guessing.
+
+### Balance-based
+
+| Provider | Display name | Credential | Source |
+|---|---|---|---|
+| deepseek / deepseek-official | DeepSeek | `DEEPSEEK_API_KEY` | Official API |
+| openai | OpenAI | `OPENAI_API_KEY` | Reference estimate (no public API) |
+| moonshotai / moonshotai-cn / kimi-coding | Kimi | `MOONSHOT_API_KEY` (fallback `KIMI_API_KEY`) | Official API |
+| openrouter | OpenRouter | `OPENROUTER_API_KEY` | Official API |
+| stepfun | StepFun | `STEPFUN_API_KEY` | Official API |
+| xiaomi | Xiaomi MiMo | `XIAOMI_API_KEY` | Official API |
+
+### Subscription-based (quota windows)
+
+| Provider | Display name | Token source |
+|---|---|---|
+| codex / chatgpt / openai-codex | ChatGPT / Codex | `~/.codex/auth.json` (read-only; decoded locally) |
+| opencode-go / opencode | OpenCode Go | `OPENCODE_GO_API_KEY` or the opencode auth file |
+| zai / zai-coding-cn | Zhipu | `ZAI_CODING_CN_API_KEY` (fallback `ZAI_API_KEY`) |
+| xiaomi-token-plan-cn / -sgp / -ams | Xiaomi MiMo | `XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY` (fallback `XIAOMI_API_KEY`) |
+
+### Cloud-billing (real monthly bill)
+
+| Provider | Display name | Credential | Source |
+|---|---|---|---|
+| together | Together | `TOGETHER_API_KEY` | Official Usage API (month spend) |
+| fireworks | Fireworks | `FIREWORKS_API_KEY` | Official Billing API (period spend) |
+| amazon-bedrock | AWS Bedrock | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Cost Explorer + Budgets (spend + budget %) |
+| cloudflare-ai-gateway / cloudflare-workers-ai | Cloudflare | `CLOUDFLARE_API_KEY` + `CLOUDFLARE_ACCOUNT_ID` (token needs Billing read) | Billable Usage API (real usage) |
+
+**Anything else** shows a **Not supported** hint instead of borrowing another provider's numbers.
+
+## Interface language
+
+The plugin follows **Settings → General → Language** in DSH. Switching languages updates the bar without a reload, and there is no separate plugin language selector. Host-side messages use DSH's saved preference; a remote browser's unsaved choice cannot change host-only text, and external provider messages keep their original wording. See [localization notes](docs/LOCALIZATION.md).
+
+## Data storage
+
+Everything the plugin records lives in its own directory, isolated from other plugins and from DSH configuration:
 
 ```
 ~/.dsh/dsh-bottom-info-bar/
-├── usage-records.json           # the complete, human-readable bill to open
-├── usage-records.journal.jsonl  # recovery journal; do not edit manually
-└── usage-records.json.bak       # previous complete snapshot for recovery
+├── usage-records.json           # the complete, human-readable ledger
+├── usage-records.journal.jsonl  # recovery journal — do not edit by hand
+└── usage-records.json.bak       # previous complete snapshot, for recovery
 ```
 
-- **Location**: `~/.dsh/dsh-bottom-info-bar/` (directory mode `0700`, file mode `0600` — readable only by the current user).
-- **Override**: set the environment variable `DSH_BOTTOM_INFO_BAR_DATA_DIR` to relocate the whole data directory (e.g. an external drive or a synced folder).
-- **View and migrate**: open `usage-records.json` in any text editor to inspect every recorded model response. To back up or move to another computer, copy the entire `~/.dsh/dsh-bottom-info-bar/` directory while DSH is closed.
-- **Contents**: one entry per model response (`id / ts / model / provider / sessionId / input / cacheRead / cacheWrite / output / currency / cost / status`). `status` is `completed` or `interrupted`; an interrupted response can still have confirmed billable usage. The billed price is fixed when the response completes, so later price-table updates never rewrite historical totals. Unknown-price models keep their token usage with `pricingStatus: "unpriced"` and are not given an invented cost. No conversation content, prompts, or API keys are ever stored.
-- **Durability**: the journal is synchronously confirmed before the UI includes a new bill. If that write fails, the bar says **Spend not saved** and the amount is not added. The readable JSON snapshot is rebuilt in the background; if it is damaged after an interruption, the last good snapshot and every intact journal line are recovered automatically. Do not manually edit the journal or backup file.
-- **Retention**: no silent entry cap. Keep the directory in normal user backups if you need long-term retention beyond this machine.
-- **Spend scope**: money is aggregated only in the active provider's currency (CNY for DeepSeek, USD for the OpenAI reference prices); records in other currencies are not mixed in. Models absent from the pricing table remain visible in the ledger but are excluded from money totals. The latest DSH `deepseek-flash` (`DeepSeek-V41-Flash` in the current DSH catalog; official release name V4.1 Flash) is priced using DeepSeek's official peak/off-peak rates.
-- **Manage records**: open **Settings → Info Bar → Billing data** to export CSV/JSON or clear the plugin’s billing records after confirmation. Settings, sign-in information and pricing data are not affected. Uninstalling the plugin does not delete your data.
+- **Permissions** — directory `0700`, files `0600`, hardened automatically at startup: readable only by your user.
+- **Relocate** — set `DSH_BOTTOM_INFO_BAR_DATA_DIR` to move the whole directory (external drive, synced folder, …).
+- **Inspect or migrate** — open `usage-records.json` in any editor. To move machines, copy the directory while DSH is closed.
+- **Contents** — one entry per model response (`id / ts / model / provider / sessionId / input / cacheRead / cacheWrite / output / currency / cost / status`), where `status` is `completed` or `interrupted`. **No conversation content, prompts, or API keys are ever stored.**
+- **Retention** — there is no silent entry cap; keep the directory in your normal backups if you need history beyond this machine.
+- **Manage** — **Settings → Info Bar → Billing data** can export CSV/JSON or clear the plugin's records after confirmation. Settings, sign-in information and pricing data are untouched, and **uninstalling does not delete your data**.
+
+> Pricing notes: money is aggregated only in the active provider's currency (CNY for DeepSeek, USD for the OpenAI reference prices) — currencies are never mixed. DeepSeek peak hours are weekdays 09:00–12:00 and 14:00–18:00 Beijing time; weekends are off-peak all day.
+>
+> On model names: DSH's catalogue calls the newest Flash model `DeepSeek-V41-Flash` (model id `deepseek-flash`), while DeepSeek's own release name is **V4.1 Flash** — the missing dot is DSH's spelling, not a typo, and the bar deliberately shows exactly what DSH shows. `DeepSeek-V4-Flash` is a *different*, older model id.
 
 ## Uninstall
 
 ```bash
 cd dsh-bottom-info-bar
-./uninstall.sh                       # remove the plugin only
+./uninstall.sh
 # or: dsh plugin --profile web remove dsh-bottom-info-bar
 ```
 
-ChatGPT subscription (binding & token maintenance) is owned by the separate plugin `dsh-chatgpt-subscription`; uninstalling this info bar does not touch it.
+After a restart the native stats row returns with no residue. Your usage records stay in `~/.dsh/dsh-bottom-info-bar/` — export or clear them from Settings → Info Bar → Billing data if you want a clean slate.
 
-After restarting, the native stats row returns automatically with no residue. Usage records remain under `~/.dsh/dsh-bottom-info-bar/`; use Settings → Info Bar → Billing data to export or clear them when you want to reset the statistics.
+ChatGPT binding and token maintenance belong to the separate plugin `dsh-chatgpt-subscription`; removing this info bar does not touch it.
 
 ## FAQ
 
-| Symptom | Fix |
+| Symptom | What to do |
 |---|---|
-| Bar does not appear after a page refresh | **Restart** `dsh web` (the host process loads plugins) |
-| Balance shows **Not configured: DEEPSEEK_API_KEY** | Add the key under Settings → Models |
-| Balance shows **Refresh failed** while a balance remains visible | Transient network/key issue; retries automatically after 60 s. The last successful data is kept so the bar never goes blank. **Hover over the warning** for a detailed explanation and retry timing. |
-| OpenCode Go shows **Refresh failed** with a missing-credentials tooltip | Add `OPENCODE_GO_API_KEY` under Settings → Models, or configure OpenCode Go in the opencode CLI |
-| How do I bind my ChatGPT subscription? | Install the companion plugin **dsh-chatgpt-subscription** and authorize on the official page — it maintains the token this bar reads for quota display |
-| ChatGPT plan or expiry is empty | Sign in again or rebind the companion plugin. If the token does not contain those fields, the bar keeps only the provider and model instead of guessing. |
-| Why does compact mode show a different window? | Compact mode prioritizes the shortest-duration window (5-hour > weekly > monthly) because it refreshes fastest. If the 5-hour window is unavailable, it falls back to weekly or monthly. **Quota and countdown always match** — both come from the same window. |
-| Why is the model's reasoning process not shown? | DSH does not render the model's internal reasoning in the UI — a DSH interface-layer limitation, not the plugin's |
-| Want the original stats row back | Uninstall the plugin and restart |
+| Bar does not appear after refreshing the page | **Restart** `dsh web` — the host composes plugins at startup |
+| Balance says **Not configured: DEEPSEEK_API_KEY** | Add the key under Settings → Models |
+| Balance shows **Refresh failed** but a figure is still visible | Transient network or key issue; it retries automatically after 60 s and keeps the last known value. **Hover the warning** for details. |
+| OpenCode Go shows **Refresh failed** with a missing-credentials tooltip | Add `OPENCODE_GO_API_KEY` under Settings → Models, or log in with the opencode CLI |
+| ChatGPT shows **Not connected** | Install the companion plugin `dsh-chatgpt-subscription` and sign in |
+| ChatGPT plan or expiry is blank | Sign in again or rebind. If the token genuinely lacks those fields the bar leaves them empty rather than guessing. |
+| How do I update? | Click the red **Update available** label to copy the command, then restart `dsh web`. See [Updating](#updating). |
+| Compact mode shows a different quota window than full mode | Intentional: compact prefers the shortest window (5-hour > weekly > monthly). Quota and countdown still come from the same window. |
+| Why is the model's reasoning not shown? | DSH does not render internal reasoning — a DSH interface limitation, not this plugin |
+| I want the original stats row back | Uninstall and restart |
 
 ## Development
 
-- **Source**: `plugin/src/host.js` (host) + `plugin/src/client-bundle.js` (client)
-- **Build**: `cd plugin && npm run build` (generates `lib/`)
-- **Test**: `node tests/run-all.mjs`
+- **Source** — `plugin/src/host.js` (host) and `plugin/src/client-bundle.js` (client)
+- **Build** — `cd plugin && npm run build` (generates `lib/`)
+- **Test** — `node tests/run-all.mjs` (builds first, then runs every suite)
+- **Contributing** — [CONTRIBUTING.md](CONTRIBUTING.md); day-to-day workflow and release process: [docs/WORKFLOW.md](docs/WORKFLOW.md)
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,176 +7,206 @@
 [![Last commit](https://img.shields.io/github/last-commit/songoao25/dsh-bottom-info-bar)](https://github.com/songoao25/dsh-bottom-info-bar)
 [![CI](https://img.shields.io/github/actions/workflow/status/songoao25/dsh-bottom-info-bar/ci.yml)](https://github.com/songoao25/dsh-bottom-info-bar/actions)
 
-**DeepSeek Harness 的信息栏插件**：在一行里显示服务商和模型、余额或订阅额度、当前价格时段与实际花费。它会自动跟随当前会话，不需要另外维护模型列表；安装一次，每次启动自动生效。
+DeepSeek Harness 输入框下方那行统计栏的**直接替代品**。
 
-## 展示预览
+原生统计栏有的（轮次与步数、LLM 耗时、工具调用、缓存命中率、输入输出 token）它**全部保留**，另外补上干活时真正想随时看到的东西：**真实余额**（或订阅额度、或本月真实账单）、**服务商与具体模型**、**高峰/空闲价格**与切换倒计时，以及**本对话已经花了多少**。
 
-![底部信息栏预览：ChatGPT 订阅账户、DeepSeek API 接入和 OpenCode Go 订阅账户](/assets/bottom-info-bar-preview.jpeg)
+装一次、重启一次，之后每次启动自动生效。计费模式自动识别，**从不显示估算数据**。
 
-长图从上至下依次展示 **ChatGPT 订阅账户**、**DeepSeek API 接入** 和 **OpenCode Go 订阅账户**；每种账户均依次展示**完整模式**和**简洁模式**。
+![信息栏预览：ChatGPT 订阅、DeepSeek 余额、OpenCode Go 订阅，各含完整与简洁两种视图](assets/bottom-info-bar-preview.jpeg)
 
-## 特性
+<sub>截图为中文界面；DSH 语言设为 English 时文案会自动切换。图中自上而下三组：**ChatGPT 订阅**、**DeepSeek 余额**、**OpenCode Go 订阅**——每组都是先**完整**视图、后**简洁**视图。</sub>
 
-- **三态信息栏**：自动检测当前服务商是**订阅制**（额度窗口，如 Codex / OpenCode Go / 智谱 / 小米 Token Plan）、**账单制**（本月真实账单，如 Together / Fireworks / AWS Bedrock / Cloudflare）还是**余额制**，三种模式互斥替换、绝不叠加；余额制保持原样。
-- **ChatGPT 订阅卡（纯本地）**：当前服务商为 **ChatGPT / Codex** 时，本地解码 `~/.codex/auth.json` 的登录令牌，直接显示**真实套餐档位 + 到期日期**，例如 `ChatGPT · Plus | 到期 2026-09-16`——纯本地解析、零网络请求，展示 OpenAI 官方登录态中的真实订阅信息，不做任何本地估算。未登录时显示「未绑定」引导。**绑定 / 令牌续期 / ChatGPT 模型路由不在本插件内**——请安装配套插件 [**dsh-chatgpt-subscription**](https://github.com/songoao25)（独立仓库）绑定 ChatGPT 账号；本插件只读令牌显示信息。
-- **订阅额度显示（OpenCode Go / 智谱 / 小米 MiMo Token Plan）**：当前服务商为订阅制时，信息栏显示**订阅服务 + 模型**（如 `OpenCode Go · V4 Flash`，小米显示 `小米 MiMo`），**5小时 / 周 / 月** 窗口**剩余额度**（剩余 = 100 − 已用，数值加粗），以及**距重置倒计时**（如 `距重置 1d 21h`）。**额度与倒计时严格来自同一窗口**。额度来源：
-  - **OpenCode Go**：经 `OPENCODE_GO_API_KEY`（设置 → 模型）或 opencode CLI 登录（`~/.local/share/opencode/auth.json` 的 `opencode-go` 条目）读取 `opencode.ai/zen/go/v1/usage` 额度；未配置时显示「未配置 OpenCode Go」引导，不报错
-  - **智谱**：经 `ZAI_CODING_CN_API_KEY`（回退 `ZAI_API_KEY`）读取 GLM Coding Plan 套餐额度；未配置时显示引导，不报错
-  - **小米 MiMo Token Plan**：经 `XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY`（按地区，回退 `XIAOMI_API_KEY`）读取月度 Credits 额度；未配置时显示引导，不报错
-- **账单型显示（本月真实账单）**：当前服务商为 **Together / Fireworks / AWS Bedrock / Cloudflare** 时，从官方计费 API 读取**本月真实已用金额**，显示如 `Together | 本月 $12.34`、`AWS Bedrock | 本月 $45.60 · 预算 46%`；Cloudflare 在接口提供免费额度时额外显示每日免费额度剩余与零点重置倒计时（接口给不出免费额度时只显示真实用量，绝不编造）。账单数据全部来自服务商官方返回，**不做任何本地估算显示**；无凭据时显示「未配置」引导
-- **一体替换**：默认替换原生统计栏，原生信息（轮·步 / LLM 耗时 / 工具调用 / 缓存命中 / 输入输出 tokens）照常显示、格式与原生一致；**首 token 平均 / tok/s** 两个速度指标移入 hover 浮窗，单行一眼看完
-- **服务商 + 具体模型**：直接读取 DSH 当前模型列表中的名称（例如官方 V4.1 Flash 显示为 `DeepSeek-V41-Flash`），新模型会自动跟随，不需要再改插件代码。模型还没读到时会明确显示“正在读取”，不会拿其他模型或默认模型代替
-- **余额更新**：读取 DeepSeek `/user/balance` 真实 API；信息栏打开、刷新或切换服务商时立即查询，之后每 60 秒自动更新。它不是服务商推送的毫秒级实时流，服务商自身的账单延迟仍以对方为准；暂时失败时保留上次数据并提示，不中断使用
-- **峰谷价 + 倒计时**：高峰价（琥珀色加粗）/ 空闲价（绿色加粗）+ 距下次切换倒计时；无峰谷价的服务商自动隐藏
-- **真实花费**：逐请求记账（`llm/stream` usage × 单价），按 **本会话（含子代理）/ 今天 / 近一月 / 全部** 精确聚合——子代理与主会话同属一个服务商账户，其记录按"会话起点 + 同账户"一并计入本会话花费；**记账数据落盘持久化（重启不丢失）**
-- **数字加粗**：余额、倒计时、花费与统计数字统一加粗，一目了然
-- **完整 / 简洁**：单击整条信息栏在两态间切换（防抖 + 严格两态）
-- **余额预警**：余额低于 ¥20 时显示 ⚠
-- **只显示真实数据**：信息栏只显示各服务商官方真实返回的余额 / 额度 / 套餐 / 账单；任何本地估算花费一律不显示
-- **「信息栏」设置页**：按内容分组，可分别显示或隐藏每一项并调整颜色；列表支持搜索，展开后在卡片内滚动，页面不会跟着变形。设置会自动保存，并提供「恢复默认显示」「恢复默认颜色」；还可以导出账单为 CSV / JSON，或在确认后清除本插件保存的账单记录
-- **长期使用不卡顿（v1.9）**：账单明细自动归档为汇总、统计增量计算——信息栏刷新不再随使用时长变慢；账本文件权限启动时自动收紧
+## 一眼看懂
 
-## 支持的服务商（v1.7）
+- **三种计费模式自动切换** —— 余额制、订阅额度制、云账单制，互斥不重叠，无需手动选择。
+- **只用真实数据** —— 余额、额度、套餐、账单全部来自各家官方 API，本地不做任何估算。
+- **与 DSH 显示完全一致** —— 服务商与模型名取自 DSH 模型切换器，新模型自动跟随，不用改插件。
+- **高峰 / 空闲价** —— 两个价格并列，并给出切换倒计时（周末全天空闲价）。
+- **诚实的花费记账** —— 本对话（含子代理）、今天、近 30 天、累计，落盘保存，重启不丢。
+- **原生观感** —— 顶替原生统计栏而不是并列重复；点击切换完整/简洁，字段与配色可在设置里自选。
 
-插件会自动跟随 DSH 当前会话的模型识别服务商——**零配置，配好密钥即可显示**。如果模型信息暂时不可用，插件会等待并显示待识别状态，不会猜测或借用其他模型的数据。
-
-### 余额制服务商
-| 服务商 | 显示名称 | 凭据键名 | 余额 API |
-|---|---|---|---|
-| deepseek / deepseek-official | DeepSeek | DEEPSEEK_API_KEY | 官方 API |
-| openai | OpenAI | OPENAI_API_KEY | 估算（无公开 API） |
-| moonshotai / moonshotai-cn / kimi-coding | Kimi | MOONSHOT_API_KEY（回退 KIMI_API_KEY） | 官方 API |
-| openrouter | OpenRouter | OPENROUTER_API_KEY | 官方 API |
-| stepfun | 阶跃星辰 | STEPFUN_API_KEY | 官方 API |
-| xiaomi | 小米 MiMo | XIAOMI_API_KEY | 官方 API |
-
-### 订阅制服务商（额度窗口）
-| 服务商 | 显示名称 | 令牌来源 |
-|---|---|---|
-| codex / chatgpt / openai-codex | ChatGPT / Codex | `~/.codex/auth.json`（本插件只读，纯本地解码显示套餐 + 到期） |
-| opencode-go / opencode | OpenCode Go | OPENCODE_GO_API_KEY 或 opencode auth.json |
-| zai / zai-coding-cn | 智谱 | ZAI_CODING_CN_API_KEY（回退 ZAI_API_KEY） |
-| xiaomi-token-plan-cn / -sgp / -ams | 小米 MiMo | XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY（回退 XIAOMI_API_KEY） |
-
-### 账单制服务商（本月真实账单）
-| 服务商 | 显示名称 | 凭据键名 | 账单 API |
-|---|---|---|---|
-| together | Together | TOGETHER_API_KEY | 官方 Usage API（本月已用金额） |
-| fireworks | Fireworks | FIREWORKS_API_KEY | 官方 Billing 接口（本周期已用金额） |
-| amazon-bedrock | AWS Bedrock | AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY | AWS Cost Explorer + Budgets（本月花费 + 预算%） |
-| cloudflare-ai-gateway / cloudflare-workers-ai | Cloudflare | CLOUDFLARE_API_KEY + CLOUDFLARE_ACCOUNT_ID（Token 需 Billing 读权限） | Billable Usage API（Alpha，本月真实用量） |
-
-**未适配服务商**：如果当前服务商不在上表中，信息栏会显示"未适配"引导，绝不显示其他服务商的余额或额度。
-
-## 环境要求
-
-- 已安装 [DeepSeek Harness](https://github.com/deepseek-ai)（`dsh` CLI）并通过 Web 界面使用（`dsh web`）
-- 已安装 [pnpm](https://pnpm.io/)（`dsh plugin` 依赖）
-
-## 安装
-
-### 方式一：一键脚本（推荐）
-
-```bash
-git clone https://github.com/songoao25/dsh-bottom-info-bar.git
-cd dsh-bottom-info-bar
-./install.sh                # 默认安装到 web profile；可用 --profile <name> 指定
-```
-
-### 方式二：NPM 安装（以后更新最方便）
+## 快速开始
 
 ```bash
 dsh plugin --profile web add dsh-bottom-info-bar
 ```
 
-以后更新：
+然后 **重启 `dsh web`** —— 插件在宿主进程启动时组合，**刷新页面不够**。
 
-```bash
-dsh plugin --profile web update dsh-bottom-info-bar --latest
-```
+在 DSH 的 **设置 → 模型** 里配好服务商的 API Key 即可，其余无需配置。
 
-### 方式三：从本地代码安装
+<details>
+<summary>其它安装方式（以及该怎么选）</summary>
+
+**推荐用上面的 npm 命令。** 它是唯一能让内置的版本更新提醒给你一条可用更新命令的安装方式——见 [更新版本](#更新版本)。
+
+**从本地代码安装**（用于开发，或想跑未发布的代码）：
 
 ```bash
 git clone https://github.com/songoao25/dsh-bottom-info-bar.git
 dsh plugin --profile web add /path/to/dsh-bottom-info-bar/plugin
 ```
 
-> **安装或更新后需重启 `dsh web`**：插件在宿主进程启动时组合加载，仅刷新页面不足以生效。
+这会产生 `link:` 安装：它跟随你的本地代码而不是 npm，所以更新方式是 `git pull` 而不是装包——见 [更新版本](#更新版本)。
 
-详细安装、故障排查与升级说明见 [docs/INSTALL.md](docs/INSTALL.md)。
+**一键脚本** —— clone 与安装一步完成：
 
-## 使用
+```bash
+git clone https://github.com/songoao25/dsh-bottom-info-bar.git
+cd dsh-bottom-info-bar
+./install.sh                # 默认装到 web profile；用 --profile <name> 改
+```
 
-- **hover 查看详情**：余额金额、输入/缓存/输出单价、下次价格切换时刻、本会话花费（含子代理；今天 / 近一月 / 全部）
-- **单击信息栏**：切换 完整 / 简洁 两态
-- **版本提醒**：每次 DSH 完全启动时检查一次 NPM；有新版本时显示红色 `↑ vX.Y.Z`。它只负责提醒，不会自动更新代码；可把提醒告诉有本机终端权限的 Agent 协助更新。
+与「从本地代码安装」一样，这同样是 `link:` 安装。
 
-## 配置
+详细步骤与故障排查见 [docs/INSTALL.md](docs/INSTALL.md)。
+</details>
 
-- **API Key**：在 **设置 → 模型** 中配置 DeepSeek API Key（环境变量名 `DEEPSEEK_API_KEY`）。未配置时信息栏给出引导文案，其余功能不受影响。
-- **模式**：只按当前会话的服务商自动选择余额、订阅额度或账单显示；不需要手动指定模式。
-- **数据口径**：高峰时段为北京时间 9:00–12:00、14:00–18:00；价格表内置 DeepSeek V4 系列与 OpenAI 参考价，未收录模型不参与花费统计。
-- **订阅额度数据源**：
-  - **ChatGPT（Codex）**：安装配套插件 [**dsh-chatgpt-subscription**](https://github.com/songoao25)（独立仓库）并绑定 ChatGPT 账号一次——该插件负责维护 `~/.codex/auth.json`（0600）中的令牌并注册 ChatGPT 模型。本信息栏**只读**令牌中的真实套餐与到期信息，**不续期、不写回、不注入凭据**；无令牌显示「未绑定 — 安装 dsh-chatgpt-subscription 授权」引导。token 绝不打印 / 进日志 / 入库
-  - **OpenCode Go**：在 **设置 → 模型** 配置 `OPENCODE_GO_API_KEY`，或先用 opencode CLI 登录订阅（写入 `~/.local/share/opencode/auth.json` 的 `opencode-go` 条目）。未配置时显示"未配置 OpenCode Go"引导，不报错。
+## 三种计费模式
 
-#### ChatGPT 订阅：已知限制
+信息栏跟随 DSH 的当前会话，按服务商自动决定显示内容，**无需手动切换模式**。
 
-- 本插件只读取配套插件写入的本地令牌字段；令牌没有套餐或到期信息时，信息栏会留空，不会自行猜测
-- 可用模型以订阅计划为准，模型接入由配套插件 **dsh-chatgpt-subscription** 提供
+### 余额制（DeepSeek / Kimi / OpenRouter / StepFun / 小米 MiMo / OpenAI 参考价）
 
-### 数据存储（插件专属目录）
+显示服务商官方接口返回的**真实余额**。信息栏打开、刷新、或切换服务商时会立即重新查询，之后每 60 秒轮询一次。查询失败时保留上一次的快照，**这一行永远不会变空白**。
 
-本插件的金额数据独立保存在自己的数据目录，与其他插件 / DSH 配置互不干扰：
+余额低于 ¥20 时，金额与「低」标记转为红色。
+
+### 订阅额度制（ChatGPT / Codex、OpenCode Go、智谱、小米 MiMo Token Plan）
+
+显示**各窗口剩余额度**（5 小时 / 周 / 月，剩余 = 100 − 已用）与**距下次重置的倒计时**。额度与倒计时**永远取自同一个窗口**，不会互相矛盾。
+
+- **ChatGPT / Codex** —— 在**本机离线解析** `~/.codex/auth.json`，显示真实套餐与到期时间（例如 `ChatGPT · Plus | Expires 2026-09-16`）。**零网络请求**：数值直接来自 OpenAI 自己的登录令牌，不做估算。未登录 → 显示**刷新失败**并提示重新授权。令牌的**绑定与续期**由配套插件 [dsh-chatgpt-subscription](https://github.com/songoao25) 负责——本插件**只读**令牌，绝不写回。
+- **OpenCode Go** —— 通过 `OPENCODE_GO_API_KEY`（设置 → 模型）或 opencode CLI 的登录（`~/.local/share/opencode/auth.json`）读取 `opencode.ai/zen/go/v1/usage` 的额度。未配置 → 显示「未配置」提示而非报错。
+- **智谱** —— 通过 `ZAI_CODING_CN_API_KEY`（回退 `ZAI_API_KEY`）读取 GLM Coding Plan 额度：套餐档位 + 5 小时窗口。
+- **小米 MiMo Token Plan** —— 通过 `XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY` 按区域读取月度 Credits 额度（回退 `XIAOMI_API_KEY`）：套餐名 + 月度窗口。
+
+简洁模式下优先显示**时长最短的窗口**（5 小时 > 周 > 月），因为它刷新最快；5 小时窗口不可用时依次回退到周、月。
+
+### 账单制（Together / Fireworks / AWS Bedrock / Cloudflare）
+
+显示官方账单接口返回的**本月真实花费**，例如 `Together | 本月 $12.34`、`AWS Bedrock | 本月 $45.60 · 预算 46%`。Cloudflare 还会显示每日免费额度剩余与 UTC 零点重置倒计时——**但仅在接口确实返回免费额度时才显示**；否则只显示真实用量，**绝不编造额度**。未配置密钥 → 显示「未配置」提示。
+
+## 花费记账
+
+每一次 `llm/stream` 请求都会被记录（用量 × 单价），并按四个口径聚合：**本对话**（含子代理）、**今天**、**近 30 天**、**累计**。
+
+子代理与主会话走同一个服务商账户，因此其花费会并入当前会话。**单价在响应完成的那一刻锁定**，之后的价目表更新绝不会改写历史金额。价目表中没有的模型保留 token 用量但不计入金额，也**不会被编造出一个价格**。
+
+重启不丢：新账目会先把流水**同步落盘确认**，再计入界面；若这次写入失败，信息栏会明确显示**账单未保存**，而不是悄悄少算一笔。账本明细会自动归档成汇总、统计增量计算，因此用上几个月界面刷新也不会变慢。
+
+## 更新版本
+
+插件在一次完整的 DSH 启动后检查一次 npm 上是否有新版本。有新版时，信息栏会出现红色的**新版本提醒**标签。
+
+**点击这个标签**，更新命令就会复制到剪贴板——粘到终端执行，然后重启 `dsh web` 即可。复制成功后标签会短暂显示「更新命令已复制」。
+
+把鼠标停在标签上会说明两条路径：让有终端权限的 Agent 帮你更新，或者点击标签自己复制命令。
+
+复制的命令与你的安装方式匹配：
+
+| 你的安装方式 | 拿到的命令 |
+|---|---|
+| npm（`dsh plugin add dsh-bottom-info-bar`） | `dsh plugin --profile <profile> add dsh-bottom-info-bar@latest` |
+| `link:`（本地代码 / 一键脚本） | `git -C <你的代码目录> pull --ff-only` |
+
+**它绝不会自动执行更新。** 插件只负责告诉你「有新版本」，在你亲手运行命令之前，机器上不会有任何改动。
+
+## 支持的服务商
+
+信息栏从 DSH 当前模型列表识别服务商——**零配置**。在 DSH 的「设置 → 模型」里配好密钥即可。DSH 尚未提供模型时，信息栏会**等待**，而不是猜一个。
+
+### 余额制
+
+| 服务商 | 显示名 | 凭据 | 数据来源 |
+|---|---|---|---|
+| deepseek / deepseek-official | DeepSeek | `DEEPSEEK_API_KEY` | 官方接口 |
+| openai | OpenAI | `OPENAI_API_KEY` | 参考价估算（官方无公开接口） |
+| moonshotai / moonshotai-cn / kimi-coding | Kimi | `MOONSHOT_API_KEY`（回退 `KIMI_API_KEY`） | 官方接口 |
+| openrouter | OpenRouter | `OPENROUTER_API_KEY` | 官方接口 |
+| stepfun | StepFun | `STEPFUN_API_KEY` | 官方接口 |
+| xiaomi | 小米 MiMo | `XIAOMI_API_KEY` | 官方接口 |
+
+### 订阅额度制（额度窗口）
+
+| 服务商 | 显示名 | 令牌来源 |
+|---|---|---|
+| codex / chatgpt / openai-codex | ChatGPT / Codex | `~/.codex/auth.json`（只读，本机解析） |
+| opencode-go / opencode | OpenCode Go | `OPENCODE_GO_API_KEY` 或 opencode 登录文件 |
+| zai / zai-coding-cn | 智谱 | `ZAI_CODING_CN_API_KEY`（回退 `ZAI_API_KEY`） |
+| xiaomi-token-plan-cn / -sgp / -ams | 小米 MiMo | `XIAOMI_TOKEN_PLAN_CN/SGP/AMS_API_KEY`（回退 `XIAOMI_API_KEY`） |
+
+### 账单制（本月真实账单）
+
+| 服务商 | 显示名 | 凭据 | 数据来源 |
+|---|---|---|---|
+| together | Together | `TOGETHER_API_KEY` | 官方用量接口（本月花费） |
+| fireworks | Fireworks | `FIREWORKS_API_KEY` | 官方账单接口（周期花费） |
+| amazon-bedrock | AWS Bedrock | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Cost Explorer + Budgets（花费 + 预算占比） |
+| cloudflare-ai-gateway / cloudflare-workers-ai | Cloudflare | `CLOUDFLARE_API_KEY` + `CLOUDFLARE_ACCOUNT_ID`（令牌需 Billing 读权限） | 计费用量接口（真实用量） |
+
+**不在列表中的服务商**会显示**不支持**提示，而不是拿别的服务商的数据顶上。
+
+## 界面语言
+
+插件跟随 DSH 的 **设置 → 通用 → 语言**。切换语言无需刷新页面即可生效，插件**没有**独立的语言开关。宿主侧文案使用 DSH 已保存的语言偏好；远程浏览器里未保存的语言选择无法改变宿主文案；来自外部服务商/系统的消息保持原文。详见[本地化说明](docs/LOCALIZATION.md)。
+
+## 数据存储
+
+插件记录的一切都放在它自己的目录里，与其它插件和 DSH 配置完全隔离：
 
 ```
 ~/.dsh/dsh-bottom-info-bar/
-├── usage-records.json           # 当前账单明细
-├── usage-records.journal.jsonl  # 恢复用日志
-├── usage-records.json.bak       # 最近一次完整快照
-├── usage-summaries.json         # 加速统计的汇总
-└── usage-archive/               # 已归档的历史明细
+├── usage-records.json           # 完整账本，人类可读
+├── usage-records.journal.jsonl  # 恢复用流水，请勿手改
+└── usage-records.json.bak       # 上一份完整快照，用于恢复
 ```
 
-- **位置**：`~/.dsh/dsh-bottom-info-bar/`（目录权限 0700、文件权限 0600，仅当前用户可读）
-- **覆盖**：设置环境变量 `DSH_BOTTOM_INFO_BAR_DATA_DIR` 可将整个数据目录改到别处（如移动硬盘 / 云同步目录）
-- **内容**：每条记录为一次 `llm/stream` 请求的用量（`ts / model / provider / sessionId / input / cacheRead / cacheWrite / output`），**不含任何对话内容与 API Key**
-- **保留**：不会悄悄删掉账单明细；历史记录会自动归档，长期备份时请一并保存整个目录
-- **花费口径**：按当前服务商币种聚合（DeepSeek 为 CNY，OpenAI 参考价为 USD），跨币种记录不混加；未收录模型不参与花费统计。最新 DSH 目录中的 `deepseek-flash`（当前 DSH 显示为 `DeepSeek-V41-Flash`，官方发布名为 V4.1 Flash）可以正常识别，并按 DeepSeek 官网公布的高峰/空闲价格计费。
-- **管理记录**：在「设置 → 信息栏 → 账单数据」中导出 CSV / JSON，或确认后清除全部账单记录；设置、登录信息和定价数据不会受影响
+- **权限** —— 目录 `0700`、文件 `0600`，启动时自动收敛：只有你自己的账户可读。
+- **换位置** —— 设置环境变量 `DSH_BOTTOM_INFO_BAR_DATA_DIR` 可整体迁移（外置硬盘、同步盘等）。
+- **查看与迁移** —— 用任意编辑器打开 `usage-records.json`。换电脑时，在 DSH 关闭状态下整目录拷贝即可。
+- **内容** —— 每条模型响应一条记录（`id / ts / model / provider / sessionId / input / cacheRead / cacheWrite / output / currency / cost / status`），`status` 为 `completed` 或 `interrupted`。**绝不保存对话内容、提示词或 API Key。**
+- **保留** —— 没有静默的条数上限；若需要跨机器长期留存，请把该目录纳入你的常规备份。
+- **管理** —— **设置 → 信息栏 → 账单数据**可导出 CSV/JSON，或在确认后清除插件记录。设置、登录信息与价目数据不受影响；**卸载插件也不会删除你的数据**。
+
+> **计费口径**：金额只按当前服务商币种聚合（DeepSeek 为 CNY、OpenAI 参考价为 USD），跨币种绝不混加。DeepSeek 高峰时段为北京时间工作日 09:00–12:00 与 14:00–18:00；周末全天空闲价。
+>
+> **关于模型名**：DSH 目录把最新的 Flash 模型写作 `DeepSeek-V41-Flash`（模型 id 为 `deepseek-flash`），而 DeepSeek 官方发布名是 **V4.1 Flash**——少那个点是 DSH 的写法，**不是错字**；信息栏刻意与 DSH 显示保持一致。`DeepSeek-V4-Flash` 则是**另一个**更早的模型 id。
 
 ## 卸载
 
 ```bash
 cd dsh-bottom-info-bar
-./uninstall.sh                        # 仅卸载插件
-# 或：dsh plugin --profile web remove dsh-bottom-info-bar
+./uninstall.sh
+# 或手动：dsh plugin --profile web remove dsh-bottom-info-bar
 ```
 
-ChatGPT 订阅（绑定与令牌维护）由独立插件 `dsh-chatgpt-subscription` 负责，卸载本信息栏插件不会触碰它。
+重启后原生统计栏自动恢复，无残留。记账数据仍保留在 `~/.dsh/dsh-bottom-info-bar/`——想彻底清零，请在「设置 → 信息栏 → 账单数据」中导出后确认清除。
 
-重启后原生统计栏自动恢复，插件无残留。账单记录默认保留在 `~/.dsh/dsh-bottom-info-bar/`；如需重置统计，请在「设置 → 信息栏 → 账单数据」中导出或清除，不必手动删除文件。
+ChatGPT 的绑定与令牌维护属于独立插件 `dsh-chatgpt-subscription`，卸载本信息栏不会影响它。
 
 ## 常见问题
 
-| 现象 | 处理 |
+| 现象 | 怎么办 |
 |---|---|
-| 安装后刷新页面没看到信息栏 | 需**重启** `dsh web`（宿主进程加载插件） |
-| 余额显示「未配置 DEEPSEEK_API_KEY」 | 在 设置 → 模型 配置 DeepSeek Key |
-| 余额显示「⚠ 刷新失败，显示上次快照」 | 网络/Key 临时故障，60s 后自动重试。**将鼠标悬停在警告上**可查看详细解释和重试时间 |
-| 显示「未配置 OpenCode Go」 | 在 设置 → 模型 配置 `OPENCODE_GO_API_KEY`，或用 opencode CLI 登录 OpenCode Go |
-| 如何绑定 ChatGPT 订阅？ | 安装配套插件 **dsh-chatgpt-subscription**，在官方页面用 ChatGPT 账号授权——它维护的令牌即本信息栏额度显示所读取的令牌 |
-| ChatGPT 套餐或到期信息为空 | 请重新登录或在配套插件中重新绑定；令牌缺少相关字段时，信息栏只保留服务商和模型，不会猜测套餐或额度 |
-| 简洁模式为什么显示不同的窗口？ | 简洁模式优先显示时间最短的窗口（5小时 > 周 > 月），因为刷新最快。若 5 小时窗口不可用，则降级到周或月窗口。**额度与倒计时严格来自同一窗口**，确保信息匹配 |
-| 为什么看不到模型的思考过程？ | DSH 界面层不渲染模型的内部思考过程，属 DSH 自身界面限制，非插件问题 |
-| 想改回原生统计栏 | 卸载本插件并重启 |
+| 刷新页面后信息栏没出现 | **重启 `dsh web`** —— 宿主在启动时组合插件 |
+| 余额显示 **未配置 DEEPSEEK_API_KEY** | 到「设置 → 模型」填入密钥 |
+| 余额显示**刷新失败**但仍能看到数字 | 网络或密钥的临时问题；60 秒后自动重试，并保留上次数值。**把鼠标停在警告上**可看详情 |
+| OpenCode Go 显示**刷新失败**且提示缺少凭据 | 到「设置 → 模型」填 `OPENCODE_GO_API_KEY`，或用 opencode CLI 登录 |
+| ChatGPT 显示**未连接** | 安装配套插件 `dsh-chatgpt-subscription` 并登录 |
+| ChatGPT 的套餐或到期时间为空 | 重新登录或重新绑定。若令牌里确实没有这些字段，信息栏会留空而不是猜 |
+| 怎么更新插件？ | 点红色的**新版本提醒**标签复制命令，然后重启 `dsh web`。详见[更新版本](#更新版本) |
+| 简洁模式显示的额度窗口和完整模式不同 | 这是有意的：简洁模式优先最短窗口（5 小时 > 周 > 月）。额度与倒计时仍取自同一窗口 |
+| 为什么看不到模型的思考过程？ | DSH 不在界面上渲染内部推理——这是 DSH 界面层的限制，与本插件无关 |
+| 我想换回原来的统计栏 | 卸载插件并重启 |
 
 ## 开发
 
-- **源码**：`plugin/src/host.js`（host）+ `plugin/src/client-bundle.js`（client）
-- **构建**：`cd plugin && npm run build`（生成 `lib/`）
-- **测试**：`node tests/run-all.mjs`
+- **源码** —— `plugin/src/host.js`（宿主侧）与 `plugin/src/client-bundle.js`（客户端）
+- **构建** —— `cd plugin && npm run build`（生成 `lib/`）
+- **测试** —— `node tests/run-all.mjs`（先构建，再跑全部测试套件）
+- **参与贡献** —— [CONTRIBUTING.md](CONTRIBUTING.md)；日常流程与发布机制见 [docs/WORKFLOW.md](docs/WORKFLOW.md)
 
 ## 许可证
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -14,7 +14,9 @@
 dsh plugin --profile web add dsh-bottom-info-bar
 ```
 
-### 方式二：一键脚本
+**推荐它的实际原因**：只有这种安装方式，内置的版本更新提醒才能给你一条可直接使用的更新命令。方式二、方式三都会产生 `link:` 安装，更新走 `git pull`（见下方「更新版本」）。
+
+### 方式二：一键脚本（产生 `link:` 安装）
 
 ```bash
 git clone https://github.com/songoao25/dsh-bottom-info-bar.git
@@ -24,7 +26,7 @@ cd dsh-bottom-info-bar
 ./install.sh --profile <profile名>
 ```
 
-### 方式三：从本地代码安装
+### 方式三：从本地代码安装（产生 `link:` 安装）
 
 ```bash
 git clone https://github.com/songoao25/dsh-bottom-info-bar.git
@@ -66,14 +68,18 @@ dsh --profile web --dump-config | grep -A2 dsh-bottom-info-bar
 
 ## 更新版本
 
+**最省事的方式：点信息栏上的红色「新版本提醒」标签**，更新命令会复制到剪贴板，粘到终端执行即可（见下一节）。命令会按你的安装方式自动给出，不用自己判断。
+
+手动更新时，按当初的安装方式二选一：
+
 如果最初使用 NPM 安装：
 
 ```bash
-dsh plugin --profile web update dsh-bottom-info-bar --latest
+dsh plugin --profile web add dsh-bottom-info-bar@latest
 # 重启 dsh web
 ```
 
-如果最初使用本地代码 / symlink 安装：
+如果最初使用本地代码 / symlink 安装（方式二、方式三）：
 
 ```bash
 cd dsh-bottom-info-bar
@@ -82,11 +88,19 @@ cd plugin && node scripts/build.mjs
 # 重启 dsh web
 ```
 
-本地 symlink 安装不会被 NPM 更新命令替换；想迁移到 NPM，先移除旧安装，再执行 NPM 安装命令。
+本地 symlink 安装**不会**被 NPM 更新命令替换；想迁移到 NPM，先移除旧安装，再执行 NPM 安装命令。
+
+> 无论哪种方式，**更新后都必须重启 `dsh web`** 才会生效。
 
 ## 看到红色版本提醒怎么办
 
-如果底部信息栏出现类似 `↑ v1.3.2` 的红色文字，可以把下面这句话直接发给拥有本机终端操作权限的 Agent：
+信息栏出现红色的「新版本提醒」标签时，**直接点击该标签**即可把更新命令复制到剪贴板；粘到终端执行，然后重启 `dsh web`。
+
+- 标签悬浮提示里同时给出了另一条路径：把更新交给有本机终端权限的 Agent 处理。
+- 复制出来的命令与你的安装方式匹配（npm 装 → `dsh plugin … add …@latest`；`link:` 装 → `git -C <目录> pull --ff-only`），所以**不存在"用错命令把本地代码顶掉"的风险**。
+- **插件不会自动更新自己**：它只负责提示，并准备好命令；机器上的一切改动都由你运行命令后才发生。
+
+如果想让 Agent 代劳，可以把下面这句话发给它：
 
 > 我的 DSH 底部信息栏提示有新版本，请帮我安全更新到新版。请先判断当前是 NPM 安装还是本地 Git 安装；不要删除 `~/.dsh/dsh-bottom-info-bar/usage-records.json`，不要覆盖未提交代码，更新后提醒我重启 `dsh web`。
 


### PR DESCRIPTION
## Why

Two problems, one of them your catch.

**The front page was hard to scan.** It opened with a long paragraph, then the feature list ran to 20 dense bullets before a new user reached "how do I install this". Both READMEs now lead with: a short pitch → the preview image → a six-line **At a glance** → a one-command **Quick start**. All the depth is still there, just below the fold.

**Three things were genuinely stale or contradictory** — found while auditing:

| Problem | Where |
|---|---|
| "tell an Agent with local terminal access to help update it" — no longer how it works since 1.11.0 | README ×2, `docs/INSTALL.md` |
| Two different update commands documented (`update --latest` vs `add --latest`) | README ×2, `docs/INSTALL.md` |
| The two files recommended **different** install methods — README said the script, INSTALL.md said npm | README ×2, `docs/INSTALL.md` |

npm is now the recommended option in both, with the real reason stated: it is the only install method where the update reminder can hand over a usable command. The script and local checkout produce `link:` installs, which update with `git pull`.

## About `V41-Flash`

**It is not a typo**, and the README was right — but it never explained itself, so it reads like one. Verified against DSH's own catalogue:

| DSH catalogue `id` | DSH catalogue `name` |
|---|---|
| `deepseek-flash` | **`DeepSeek-V41-Flash`** |
| `deepseek-v4-flash` | `DeepSeek-V4-Flash` ← a different, older model |

The plugin's whole job is to mirror what DSH's model switcher shows, so `V41-Flash` is correct output. The README now states plainly that the missing dot is DSH's spelling rather than the plugin's, so the next reader does not have to wonder — which is the actual defect your question exposed.

## What was checked and left alone

The provider tables were verified against the code and are unchanged — the balance, subscription and billing id lists match `SUBSCRIPTION_PROVIDERS`, `BILLING_PROVIDERS` and the host's provider definitions exactly.

Also verified before restating: the ¥20 low-balance threshold, the 60-second balance poll, and that compact mode prefers the shortest quota window.

## Result

Both files are now exactly 213 lines and mirror each other section for section. Internal anchors and the preview image path were checked. Full suite green.
